### PR TITLE
Use temporary directory for Last-Known-IP.log

### DIFF
--- a/docs/usage/logs.md
+++ b/docs/usage/logs.md
@@ -15,3 +15,6 @@ If you set ENV variable `LOG_TO_STDOUT=true` then logs will send to STDOUT.
 
 ## `application.log`
 Application logs are written to `application.log` in root project directory.  Log files are compressed and archived after reaching 10MB in size.  The most recent 3 archives are kept in rotation.  All other archives are deleted to keep footprint small.  This is ignored if `LOG_TO_STDOUT=true`.
+
+## `Last-Known-IP.log`
+The current known IP address is written to `Last-Known-IP.log` in the OS temporary directory. This file is used to reduce the number of lookups to Route53.

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@
 // Dependencies
 const https = require('https')
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
 const AWS = require('aws-sdk')
 const log4js = require('log4js')
 const dotenv = require('dotenv')
@@ -133,7 +135,7 @@ if (SEND_EMAIL_SES) {
 }
 
 // Local variables for the process
-const LastKnownIPFileName = 'Last-Known-IP.log'
+const LastKnownIPFileName = path.join(os.tmpdir(), 'Last-Known-IP.log')
 let currentIP = ''
 let previousIP = ''
 let SentErrorEmail = false
@@ -413,6 +415,7 @@ const SendEmailNotificationAWSSES = function (EmailMessageType, EmailBodyErrorMe
 const RunScript = function () {
   if (FirstRun) {
     logger.info('First run of process.')
+    logger.info('Using', LastKnownIPFileName, 'to store last known IP address')
     RemoveFileNameIfItExists(LastKnownIPFileName)
     FirstRun = false
   } else {


### PR DESCRIPTION
This will use the OS temporary directory to store the `Last-Known-IP.log` file. I've also added documentation about the use of the file.

Closes #23.