### PR TITLE
security(node): bump node from 18.17.0 to 18.18.0 for docker base image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17
+          node-version: 18.18
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17
+          node-version: 18.18
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:18.17.0-alpine3.18
+FROM node:18.18.0-alpine3.18
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE


### PR DESCRIPTION
Closes security issues: 
- https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/222
- https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/223
- https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/224