### PR TITLE
Bump aws-sdk and markdownlint-cli2 to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "log4js": "^6.9.1"
       },
       "devDependencies": {
-        "markdownlint-cli2": "^0.8.1",
+        "markdownlint-cli2": "^0.10.0",
         "standard": "^17.1.0"
       },
       "engines": {
@@ -2535,14 +2535,14 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
         "merge2": "^1.4.1",
         "slash": "^4.0.0"
       },
@@ -3162,30 +3162,30 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
-      "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.31.1.tgz",
+      "integrity": "sha512-CKMR2hgcIBrYlIUccDCOvi966PZ0kJExDrUi1R+oF9PvqQmCrTqjOsgIvf2403OmJ+CWomuzDoylr6KbuMyvHA==",
       "dev": true,
       "dependencies": {
         "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.5"
+        "markdownlint-micromark": "0.1.7"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.8.1.tgz",
-      "integrity": "sha512-y0Siwt+RApKxSSb0CT9p7z1DcAO+ncjrB9IpC/jflJRIet4namCFmxLTbfBBQdPF6EntPk5yyXKe7vcoPGlnXw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.10.0.tgz",
+      "integrity": "sha512-kVxjPyKFC+eW7iqcxiNI50RDzwugpXkEX5eQlDso/0IUs9M73jXYguLFHDzgi5KatcxU/57Fu8KoGtkFft9lfA==",
       "dev": true,
       "dependencies": {
-        "globby": "13.1.4",
-        "markdownlint": "0.29.0",
+        "globby": "13.2.2",
+        "markdownlint": "0.31.1",
         "markdownlint-cli2-formatter-default": "0.0.4",
         "micromatch": "4.0.5",
-        "strip-json-comments": "5.0.0",
-        "yaml": "2.3.1"
+        "strip-json-comments": "5.0.1",
+        "yaml": "2.3.2"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2.js",
@@ -3206,9 +3206,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/strip-json-comments": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.0.tgz",
-      "integrity": "sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -3218,9 +3218,9 @@
       }
     },
     "node_modules/markdownlint-micromark": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
-      "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
+      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -4250,9 +4250,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -6226,14 +6226,14 @@
       }
     },
     "globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dev": true,
       "requires": {
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
         "merge2": "^1.4.1",
         "slash": "^4.0.0"
       }
@@ -6684,33 +6684,33 @@
       }
     },
     "markdownlint": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
-      "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.31.1.tgz",
+      "integrity": "sha512-CKMR2hgcIBrYlIUccDCOvi966PZ0kJExDrUi1R+oF9PvqQmCrTqjOsgIvf2403OmJ+CWomuzDoylr6KbuMyvHA==",
       "dev": true,
       "requires": {
         "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.5"
+        "markdownlint-micromark": "0.1.7"
       }
     },
     "markdownlint-cli2": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.8.1.tgz",
-      "integrity": "sha512-y0Siwt+RApKxSSb0CT9p7z1DcAO+ncjrB9IpC/jflJRIet4namCFmxLTbfBBQdPF6EntPk5yyXKe7vcoPGlnXw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.10.0.tgz",
+      "integrity": "sha512-kVxjPyKFC+eW7iqcxiNI50RDzwugpXkEX5eQlDso/0IUs9M73jXYguLFHDzgi5KatcxU/57Fu8KoGtkFft9lfA==",
       "dev": true,
       "requires": {
-        "globby": "13.1.4",
-        "markdownlint": "0.29.0",
+        "globby": "13.2.2",
+        "markdownlint": "0.31.1",
         "markdownlint-cli2-formatter-default": "0.0.4",
         "micromatch": "4.0.5",
-        "strip-json-comments": "5.0.0",
-        "yaml": "2.3.1"
+        "strip-json-comments": "5.0.1",
+        "yaml": "2.3.2"
       },
       "dependencies": {
         "strip-json-comments": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.0.tgz",
-          "integrity": "sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+          "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
           "dev": true
         }
       }
@@ -6723,9 +6723,9 @@
       "requires": {}
     },
     "markdownlint-micromark": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
-      "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
+      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
       "dev": true
     },
     "mdurl": {
@@ -7439,9 +7439,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true
     },
     "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-route-53": "^3.377.0",
-        "@aws-sdk/client-ses": "^3.377.0",
+        "@aws-sdk/client-route-53": "^3.414.0",
+        "@aws-sdk/client-ses": "^3.414.0",
         "dotenv": "^16.3.1",
         "log4js": "^6.9.1"
       },
@@ -114,48 +114,49 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-route-53": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.377.0.tgz",
-      "integrity": "sha512-YFhGCygD5lGQJqCM6GFIk9H9cQq4IbwolddM9Sob8x7z8oTPb9OK6rqyydjo1PkpvvFpMVChoMkrsPW+b3PFQg==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.414.0.tgz",
+      "integrity": "sha512-s0x95gSvOgULLy1fjvjS93D6BytJByCMgFeSWqPrnR+QFyvNkNox0cfMp0bUwqcCd/BE0BHocbEr2NX+uSQWWg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.377.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-sdk-route53": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@aws-sdk/client-sts": "3.414.0",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-sdk-route53": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "@smithy/util-waiter": "^1.0.1",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.7",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -164,46 +165,47 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.377.0.tgz",
-      "integrity": "sha512-MNWjta/z3vVJlePtuli5UxHP4uElzXMsv/ciLVji9naumZ8pfmKND16LG/lLi8Rsn0+bjQSU7jYhXgceqojTfQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.414.0.tgz",
+      "integrity": "sha512-GD9ZqzjcGk5mkgmhwnEiemyIsLUz7O/SMvwxDo9prSBlrJ0jiVxbr0JbrACfQhn3geD/VIalvHQFDvQ3OVF4wQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.377.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "@smithy/util-waiter": "^1.0.1",
+        "@aws-sdk/client-sts": "3.414.0",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.7",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -212,85 +214,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
-      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
+      "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
-      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -298,45 +258,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.377.0.tgz",
-      "integrity": "sha512-K/yTHxVtTIwU42qCxbv78eT74j+GZMCcQ5TUd2fwxEWeq8HcIWcTIhujv7F6UtdrQHrou20wZ/+jMQtVKfkXXQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
+      "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-sdk-sts": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-sdk-sts": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -345,13 +306,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
-      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
+      "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -359,19 +320,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
-      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
+      "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.370.0",
-        "@aws-sdk/credential-provider-process": "3.370.0",
-        "@aws-sdk/credential-provider-sso": "3.370.0",
-        "@aws-sdk/credential-provider-web-identity": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/credential-provider-env": "3.413.0",
+        "@aws-sdk/credential-provider-process": "3.413.0",
+        "@aws-sdk/credential-provider-sso": "3.414.0",
+        "@aws-sdk/credential-provider-web-identity": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -379,20 +340,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
-      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
+      "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.370.0",
-        "@aws-sdk/credential-provider-ini": "3.370.0",
-        "@aws-sdk/credential-provider-process": "3.370.0",
-        "@aws-sdk/credential-provider-sso": "3.370.0",
-        "@aws-sdk/credential-provider-web-identity": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/credential-provider-env": "3.413.0",
+        "@aws-sdk/credential-provider-ini": "3.414.0",
+        "@aws-sdk/credential-provider-process": "3.413.0",
+        "@aws-sdk/credential-provider-sso": "3.414.0",
+        "@aws-sdk/credential-provider-web-identity": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -400,14 +361,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
-      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
+      "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -415,16 +376,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
-      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
+      "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.370.0",
-        "@aws-sdk/token-providers": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/client-sso": "3.414.0",
+        "@aws-sdk/token-providers": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -432,13 +393,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
-      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
+      "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -446,13 +407,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
-      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
+      "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -460,12 +421,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
-      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
+      "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -473,13 +434,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
-      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
+      "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -487,12 +448,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-route53": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.370.0.tgz",
-      "integrity": "sha512-jc0ACsyRrIbOuYF7Cv/g0CpqD+HI5Qs0ML8L5jgqtKrZ5mKdl38HtovFPaZm1KUuuq1ApSnITDHNiNUUQRC6fQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.413.0.tgz",
+      "integrity": "sha512-PNdR7dZVHQ3ZHB4V7PjGpUz4ecr86BiHHK2c1SmWvjRMX3EEThAWchc8lMMiUuFHcaUd6jsggUNOdiVymVTYTw==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -500,13 +461,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
-      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
+      "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -514,16 +475,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
-      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
+      "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/signature-v4": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -531,14 +492,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
-      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
+      "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
+      "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -546,15 +522,44 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
-      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
+      "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -562,11 +567,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
+      "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
       "dependencies": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -574,11 +579,11 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
-      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
+      "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/types": "3.413.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -597,24 +602,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
-      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
+      "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
-      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
+      "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
       "dependencies": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -773,11 +778,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
+      "integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -785,13 +790,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.1.0.tgz",
-      "integrity": "sha512-7WD9eZHp46BxAjNGHJLmxhhyeiNWkBdVStd7SUJPUZqQGeIO/REtIrcIfKUfdiHTQ9jyu2SYoqvzqqaFc6987w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
+      "integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-config-provider": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -799,14 +805,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.1.0.tgz",
-      "integrity": "sha512-kUMOdEu3RP6ozH0Ga8OeMP8gSkBsK1UqZZKyPLFnpZHrtZuHSSt7M7gsHYB/bYQBZAo3o7qrGmRty3BubYtYxQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
+      "integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^1.1.0",
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/url-parser": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/types": "^2.3.3",
+        "@smithy/url-parser": "^2.0.9",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -814,36 +820,36 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
-      "integrity": "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.9.tgz",
+      "integrity": "sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.1.0.tgz",
-      "integrity": "sha512-N22C9R44u5WGlcY+Wuv8EXmCAq62wWwriRAuoczMEwAIjPbvHSthyPSLqI4S7kAST1j6niWg8kwpeJ3ReAv3xg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
+      "integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/querystring-builder": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-base64": "^1.1.0",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/querystring-builder": "^2.0.9",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.1.0.tgz",
-      "integrity": "sha512-yiNKDGMzrQjnpnbLfkYKo+HwIxmBAsv0AI++QIJwvhfkLpUTBylelkv6oo78/YqZZS6h+bGfl0gILJsKE2wAKQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
+      "integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -851,18 +857,18 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.1.0.tgz",
-      "integrity": "sha512-h2rXn68ClTwzPXYzEUNkz+0B/A0Hz8YdFNTiEwlxkwzkETGKMxmsrQGFXwYm3jd736R5vkXcClXz1ddKrsaBEQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
+      "integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
-      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -871,12 +877,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.1.0.tgz",
-      "integrity": "sha512-iNxwhZ7Xc5+LjeDElEOi/Nh8fFsc9Dw9+5w7h7/GLFIU0RgAwBJuJtcP1vNTOwzW4B3hG+gRu8sQLqA9OEaTwA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
+      "integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -884,14 +890,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.1.0.tgz",
-      "integrity": "sha512-PvpazNjVpxX2ICrzoFYCpFnjB39DKCpZds8lRpAB3p6HGrx6QHBaNvOzVhJGBf0jcAbfCdc5/W0n9z8VWaSSww==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
+      "integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
       "dependencies": {
-        "@smithy/middleware-serde": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/url-parser": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/middleware-serde": "^2.0.9",
+        "@smithy/types": "^2.3.3",
+        "@smithy/url-parser": "^2.0.9",
+        "@smithy/util-middleware": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -899,15 +905,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.1.0.tgz",
-      "integrity": "sha512-lINKYxIvT+W20YFOtHBKeGm7npuJg0/YCoShttU7fVpsmU+a2rdb9zrJn1MHqWfUL6DhTAWGa0tH2O7l4XrDcw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
+      "integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
       "dependencies": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/service-error-classification": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-middleware": "^1.1.0",
-        "@smithy/util-retry": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/service-error-classification": "^2.0.2",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-retry": "^2.0.2",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -916,11 +923,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.1.0.tgz",
-      "integrity": "sha512-RiBMxhxuO9VTjHsjJvhzViyceoLhU6gtrnJGpAXY43wE49IstXIGEQz8MT50/hOq5EumX16FCpup0r5DVyfqNQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
+      "integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -928,10 +935,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.1.0.tgz",
-      "integrity": "sha512-XynYiIvXNea2BbLcppvpNK0zu8o2woJqgnmxqYTn4FWagH/Hr2QIk8LOsUz7BIJ4tooFhmx8urHKCdlPbbPDCA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.2.tgz",
+      "integrity": "sha512-6BNfPVp/8gcmkKdJhNJK3HEkUNNTrY3hM9vuWXIUSoLk9FZo1L2QuGLGB6S124D9ySInn8PzEdOtguCF5Ao4KA==",
       "dependencies": {
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -939,13 +947,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.1.0.tgz",
-      "integrity": "sha512-2G4TlzUnmTrUY26VKTonQqydwb+gtM/mcl+TqDP8CnWtJKVL8ElPpKgLGScP04bPIRY9x2/10lDdoaRXDqPuCw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
+      "integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
       "dependencies": {
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/shared-ini-file-loader": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/shared-ini-file-loader": "^2.0.11",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -953,14 +961,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
-      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
+      "integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
       "dependencies": {
-        "@smithy/abort-controller": "^1.1.0",
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/querystring-builder": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/abort-controller": "^2.0.9",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/querystring-builder": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -968,11 +976,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.2.0.tgz",
-      "integrity": "sha512-qlJd9gT751i4T0t/hJAyNGfESfi08Fek8QiLcysoKPgR05qHhG0OYhlaCJHhpXy4ECW0lHyjvFM1smrCLIXVfw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
+      "integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -980,11 +988,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
-      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
+      "integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -992,12 +1000,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
-      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
+      "integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-uri-escape": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1005,11 +1013,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.1.0.tgz",
-      "integrity": "sha512-Lm/FZu2qW3XX+kZ4WPwr+7aAeHf1Lm84UjNkKyBu16XbmEV7ukfhXni2aIwS2rcVf8Yv5E7wchGGpOFldj9V4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
+      "integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1017,19 +1025,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
-      "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
+      "integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
+      "dependencies": {
+        "@smithy/types": "^2.3.3"
+      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.1.0.tgz",
-      "integrity": "sha512-S/v33zvCWzFyGZGlsEF0XsZtNNR281UhR7byk3nRfsgw5lGpg51rK/zjMgulM+h6NSuXaFILaYrw1I1v4kMcuA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
+      "integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
       "dependencies": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1037,17 +1048,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.1.0.tgz",
-      "integrity": "sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.9.tgz",
+      "integrity": "sha512-RkHP0joSI1j2EI+mU55sOi33/aMMkKdL9ZY+SWrPxsiCe1oyzzuy79Tpn8X7uT+t0ilNmQlwPpkP/jUy940pEA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^1.1.0",
-        "@smithy/is-array-buffer": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
-        "@smithy/util-uri-escape": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/eventstream-codec": "^2.0.9",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1055,13 +1066,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.1.0.tgz",
-      "integrity": "sha512-j32SGgVhv2G9nBTmel9u3OXux8KG20ssxuFakJrEeDug3kqbl1qrGzVLCe+Eib402UDtA0Sp1a4NZ2SEXDBxag==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.6.tgz",
+      "integrity": "sha512-+F26b8U7C6ydJgj5Y+OZ94NL54HQUPF1LrFiZjMAIX3OlgZjDhiT3m6VOZo6+hge3sEFOrupwdjB5V24JOCpQw==",
       "dependencies": {
-        "@smithy/middleware-stack": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-stream": "^1.1.0",
+        "@smithy/middleware-stack": "^2.0.2",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-stream": "^2.0.12",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1069,9 +1080,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
+      "integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1080,21 +1091,21 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.1.0.tgz",
-      "integrity": "sha512-tpvi761kzboiLNGEWczuybMPCJh6WHB3cz9gWAG95mSyaKXmmX8ZcMxoV+irZfxDqLwZVJ22XTumu32S7Ow8aQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
+      "integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
       "dependencies": {
-        "@smithy/querystring-parser": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/querystring-parser": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.1.0.tgz",
-      "integrity": "sha512-FpYmDmVbOXAxqvoVCwqehUN0zXS+lN8V7VS9O7I8MKeVHdSTsZzlwiMEvGoyTNOXWn8luF4CTDYgNHnZViR30g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1102,17 +1113,17 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.1.0.tgz",
-      "integrity": "sha512-cep3ioRxzRZ2Jbp3Kly7gy6iNVefYXiT6ETt8W01RQr3uwi1YMkrbU1p3lMR4KhX/91Nrk6UOgX1RH+oIt48RQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.1.0.tgz",
-      "integrity": "sha512-fRHRjkUuT5em4HZoshySXmB1n3HAU7IS232s+qU4TicexhyGJpXMK/2+c56ePOIa1FOK2tV1Q3J/7Mae35QVSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1121,11 +1132,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^1.1.0",
+        "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1133,9 +1144,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.1.0.tgz",
-      "integrity": "sha512-rQ47YpNmF6Is4I9GiE3T3+0xQ+r7RKRKbmHYyGSbyep/0cSf9kteKcI0ssJTvveJ1K4QvwrxXj1tEFp/G2UqxQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1144,12 +1155,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.1.0.tgz",
-      "integrity": "sha512-0bWhs1e412bfC5gwPCMe8Zbz0J8UoZ/meEQdo6MYj8Ne+c+QZ+KxVjx0a1dFYOclvM33SslL9dP0odn8kfblkg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.10.tgz",
+      "integrity": "sha512-M5eaPn961jU2glZkqvmrVd6H4Tz4j1CJ2Kt8kjqMfcWZ4IQFgwPYbRkgND0W93dZXDmFU2GtuJGatwSmWIqxrA==",
       "dependencies": {
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/smithy-client": "^2.1.6",
+        "@smithy/types": "^2.3.3",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1158,15 +1170,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.1.0.tgz",
-      "integrity": "sha512-440e25TUH2b+TeK5CwsjYFrI9ShVOgA31CoxCKiv4ncSK4ZM68XW5opYxQmzMbRWARGEMu2XEUeBmOgMU2RLsw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.12.tgz",
+      "integrity": "sha512-fwAVus2YBTU5u4KFmmEZDdgx3HpUUg8f6SEUetJFsNL+6AzoGBIhCZX0yMrVCLJEZe6tUfMbL5TZHXMw2q6MaA==",
       "dependencies": {
-        "@smithy/config-resolver": "^1.1.0",
-        "@smithy/credential-provider-imds": "^1.1.0",
-        "@smithy/node-config-provider": "^1.1.0",
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/config-resolver": "^2.0.10",
+        "@smithy/credential-provider-imds": "^2.0.12",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/smithy-client": "^2.1.6",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1174,9 +1187,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.1.0.tgz",
-      "integrity": "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1185,10 +1198,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.1.0.tgz",
-      "integrity": "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
+      "integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
       "dependencies": {
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1196,11 +1210,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
-      "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
+      "integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
       "dependencies": {
-        "@smithy/service-error-classification": "^1.1.0",
+        "@smithy/service-error-classification": "^2.0.2",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1208,17 +1223,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.1.0.tgz",
-      "integrity": "sha512-w3lsdGsntaLQIrwDWJkIFKrFscgZXwU/oxsse09aSTNv5TckPhDeYea3LhsDrU5MGAG3vprhVZAKr33S45coVA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
+      "integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^1.1.0",
-        "@smithy/node-http-handler": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-base64": "^1.1.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/fetch-http-handler": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.5",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1226,9 +1241,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
-      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1237,11 +1252,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
-      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1249,12 +1264,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.1.0.tgz",
-      "integrity": "sha512-S6FNIB3UJT+5Efd/0DeziO5Rs82QAMODHW4v2V3oNRrwaBigY/7Yx3SiLudZuF9WpVsV08Ih3BjIH34nzZiinQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.9.tgz",
+      "integrity": "sha512-Hy9Cs0FtIacC1aVFk98bm/7CYqim9fnHAPRnV/SB2mj02ExYs/9Dn5SrNQmtTBTLCn65KqYnNVBNS8GuGpZOOw==",
       "dependencies": {
-        "@smithy/abort-controller": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/abort-controller": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2227,9 +2242,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3782,9 +3797,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4361,411 +4376,416 @@
       }
     },
     "@aws-sdk/client-route-53": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.377.0.tgz",
-      "integrity": "sha512-YFhGCygD5lGQJqCM6GFIk9H9cQq4IbwolddM9Sob8x7z8oTPb9OK6rqyydjo1PkpvvFpMVChoMkrsPW+b3PFQg==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.414.0.tgz",
+      "integrity": "sha512-s0x95gSvOgULLy1fjvjS93D6BytJByCMgFeSWqPrnR+QFyvNkNox0cfMp0bUwqcCd/BE0BHocbEr2NX+uSQWWg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.377.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-sdk-route53": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@aws-sdk/client-sts": "3.414.0",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-sdk-route53": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "@smithy/util-waiter": "^1.0.1",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.7",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-ses": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.377.0.tgz",
-      "integrity": "sha512-MNWjta/z3vVJlePtuli5UxHP4uElzXMsv/ciLVji9naumZ8pfmKND16LG/lLi8Rsn0+bjQSU7jYhXgceqojTfQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.414.0.tgz",
+      "integrity": "sha512-GD9ZqzjcGk5mkgmhwnEiemyIsLUz7O/SMvwxDo9prSBlrJ0jiVxbr0JbrACfQhn3geD/VIalvHQFDvQ3OVF4wQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.377.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "@smithy/util-waiter": "^1.0.1",
+        "@aws-sdk/client-sts": "3.414.0",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.7",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
-      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
+      "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/client-sso-oidc": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
-      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.377.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.377.0.tgz",
-      "integrity": "sha512-K/yTHxVtTIwU42qCxbv78eT74j+GZMCcQ5TUd2fwxEWeq8HcIWcTIhujv7F6UtdrQHrou20wZ/+jMQtVKfkXXQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
+      "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.370.0",
-        "@aws-sdk/middleware-host-header": "3.370.0",
-        "@aws-sdk/middleware-logger": "3.370.0",
-        "@aws-sdk/middleware-recursion-detection": "3.370.0",
-        "@aws-sdk/middleware-sdk-sts": "3.370.0",
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/middleware-user-agent": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@aws-sdk/util-user-agent-browser": "3.370.0",
-        "@aws-sdk/util-user-agent-node": "3.370.0",
-        "@smithy/config-resolver": "^1.0.1",
-        "@smithy/fetch-http-handler": "^1.0.1",
-        "@smithy/hash-node": "^1.0.1",
-        "@smithy/invalid-dependency": "^1.0.1",
-        "@smithy/middleware-content-length": "^1.0.1",
-        "@smithy/middleware-endpoint": "^1.0.2",
-        "@smithy/middleware-retry": "^1.0.3",
-        "@smithy/middleware-serde": "^1.0.1",
-        "@smithy/middleware-stack": "^1.0.1",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/node-http-handler": "^1.0.2",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/smithy-client": "^1.0.3",
-        "@smithy/types": "^1.1.0",
-        "@smithy/url-parser": "^1.0.1",
-        "@smithy/util-base64": "^1.0.1",
-        "@smithy/util-body-length-browser": "^1.0.1",
-        "@smithy/util-body-length-node": "^1.0.1",
-        "@smithy/util-defaults-mode-browser": "^1.0.1",
-        "@smithy/util-defaults-mode-node": "^1.0.1",
-        "@smithy/util-retry": "^1.0.3",
-        "@smithy/util-utf8": "^1.0.1",
+        "@aws-sdk/credential-provider-node": "3.414.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-sdk-sts": "3.413.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/region-config-resolver": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
-      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
+      "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
-      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
+      "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.370.0",
-        "@aws-sdk/credential-provider-process": "3.370.0",
-        "@aws-sdk/credential-provider-sso": "3.370.0",
-        "@aws-sdk/credential-provider-web-identity": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/credential-provider-env": "3.413.0",
+        "@aws-sdk/credential-provider-process": "3.413.0",
+        "@aws-sdk/credential-provider-sso": "3.414.0",
+        "@aws-sdk/credential-provider-web-identity": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
-      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
+      "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.370.0",
-        "@aws-sdk/credential-provider-ini": "3.370.0",
-        "@aws-sdk/credential-provider-process": "3.370.0",
-        "@aws-sdk/credential-provider-sso": "3.370.0",
-        "@aws-sdk/credential-provider-web-identity": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/credential-provider-imds": "^1.0.1",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/credential-provider-env": "3.413.0",
+        "@aws-sdk/credential-provider-ini": "3.414.0",
+        "@aws-sdk/credential-provider-process": "3.413.0",
+        "@aws-sdk/credential-provider-sso": "3.414.0",
+        "@aws-sdk/credential-provider-web-identity": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
-      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
+      "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
-      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
+      "version": "3.414.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
+      "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
       "requires": {
-        "@aws-sdk/client-sso": "3.370.0",
-        "@aws-sdk/token-providers": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/client-sso": "3.414.0",
+        "@aws-sdk/token-providers": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
-      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
+      "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
-      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
+      "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
-      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
+      "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
-      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
+      "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-route53": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.370.0.tgz",
-      "integrity": "sha512-jc0ACsyRrIbOuYF7Cv/g0CpqD+HI5Qs0ML8L5jgqtKrZ5mKdl38HtovFPaZm1KUuuq1ApSnITDHNiNUUQRC6fQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.413.0.tgz",
+      "integrity": "sha512-PNdR7dZVHQ3ZHB4V7PjGpUz4ecr86BiHHK2c1SmWvjRMX3EEThAWchc8lMMiUuFHcaUd6jsggUNOdiVymVTYTw==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
-      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
+      "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/middleware-signing": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
-      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
+      "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/signature-v4": "^1.0.1",
-        "@smithy/types": "^1.1.0",
-        "@smithy/util-middleware": "^1.0.1",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
-      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
+      "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@aws-sdk/util-endpoints": "3.370.0",
-        "@smithy/protocol-http": "^1.1.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
+      "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
-      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
+      "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.370.0",
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/property-provider": "^1.0.1",
-        "@smithy/shared-ini-file-loader": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.413.0",
+        "@aws-sdk/middleware-logger": "3.413.0",
+        "@aws-sdk/middleware-recursion-detection": "3.413.0",
+        "@aws-sdk/middleware-user-agent": "3.413.0",
+        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/util-endpoints": "3.413.0",
+        "@aws-sdk/util-user-agent-browser": "3.413.0",
+        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/hash-node": "^2.0.7",
+        "@smithy/invalid-dependency": "^2.0.7",
+        "@smithy/middleware-content-length": "^2.0.9",
+        "@smithy/middleware-endpoint": "^2.0.7",
+        "@smithy/middleware-retry": "^2.0.10",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.4",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.8",
+        "@smithy/util-defaults-mode-node": "^2.0.10",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
-      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
+      "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
       "requires": {
-        "@smithy/types": "^1.1.0",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
-      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
+      "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/types": "3.413.0",
         "tslib": "^2.5.0"
       }
     },
@@ -4778,24 +4798,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
-      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
+      "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/types": "^2.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.370.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
-      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
+      "version": "3.413.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
+      "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
       "requires": {
-        "@aws-sdk/types": "3.370.0",
-        "@smithy/node-config-provider": "^1.0.1",
-        "@smithy/types": "^1.1.0",
+        "@aws-sdk/types": "3.413.0",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4903,389 +4923,399 @@
       }
     },
     "@smithy/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
+      "integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/config-resolver": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.1.0.tgz",
-      "integrity": "sha512-7WD9eZHp46BxAjNGHJLmxhhyeiNWkBdVStd7SUJPUZqQGeIO/REtIrcIfKUfdiHTQ9jyu2SYoqvzqqaFc6987w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
+      "integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
       "requires": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-config-provider": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.2",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.1.0.tgz",
-      "integrity": "sha512-kUMOdEu3RP6ozH0Ga8OeMP8gSkBsK1UqZZKyPLFnpZHrtZuHSSt7M7gsHYB/bYQBZAo3o7qrGmRty3BubYtYxQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
+      "integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
       "requires": {
-        "@smithy/node-config-provider": "^1.1.0",
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/url-parser": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/types": "^2.3.3",
+        "@smithy/url-parser": "^2.0.9",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
-      "integrity": "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.9.tgz",
+      "integrity": "sha512-sy0pcbKnawt1iu+qCoSFbs/h9PAaUgvlJEO3lqkE1HFFj4p5RgL98vH+9CyDoj6YY82cG5XsorFmcLqQJHTOYw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.1.0.tgz",
-      "integrity": "sha512-N22C9R44u5WGlcY+Wuv8EXmCAq62wWwriRAuoczMEwAIjPbvHSthyPSLqI4S7kAST1j6niWg8kwpeJ3ReAv3xg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
+      "integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
       "requires": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/querystring-builder": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-base64": "^1.1.0",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/querystring-builder": "^2.0.9",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.1.0.tgz",
-      "integrity": "sha512-yiNKDGMzrQjnpnbLfkYKo+HwIxmBAsv0AI++QIJwvhfkLpUTBylelkv6oo78/YqZZS6h+bGfl0gILJsKE2wAKQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
+      "integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
       "requires": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.1.0.tgz",
-      "integrity": "sha512-h2rXn68ClTwzPXYzEUNkz+0B/A0Hz8YdFNTiEwlxkwzkETGKMxmsrQGFXwYm3jd736R5vkXcClXz1ddKrsaBEQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
+      "integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
-      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
+      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.1.0.tgz",
-      "integrity": "sha512-iNxwhZ7Xc5+LjeDElEOi/Nh8fFsc9Dw9+5w7h7/GLFIU0RgAwBJuJtcP1vNTOwzW4B3hG+gRu8sQLqA9OEaTwA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
+      "integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
       "requires": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.1.0.tgz",
-      "integrity": "sha512-PvpazNjVpxX2ICrzoFYCpFnjB39DKCpZds8lRpAB3p6HGrx6QHBaNvOzVhJGBf0jcAbfCdc5/W0n9z8VWaSSww==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
+      "integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
       "requires": {
-        "@smithy/middleware-serde": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/url-parser": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/middleware-serde": "^2.0.9",
+        "@smithy/types": "^2.3.3",
+        "@smithy/url-parser": "^2.0.9",
+        "@smithy/util-middleware": "^2.0.2",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.1.0.tgz",
-      "integrity": "sha512-lINKYxIvT+W20YFOtHBKeGm7npuJg0/YCoShttU7fVpsmU+a2rdb9zrJn1MHqWfUL6DhTAWGa0tH2O7l4XrDcw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
+      "integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
       "requires": {
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/service-error-classification": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-middleware": "^1.1.0",
-        "@smithy/util-retry": "^1.1.0",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/service-error-classification": "^2.0.2",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-retry": "^2.0.2",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.1.0.tgz",
-      "integrity": "sha512-RiBMxhxuO9VTjHsjJvhzViyceoLhU6gtrnJGpAXY43wE49IstXIGEQz8MT50/hOq5EumX16FCpup0r5DVyfqNQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
+      "integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.1.0.tgz",
-      "integrity": "sha512-XynYiIvXNea2BbLcppvpNK0zu8o2woJqgnmxqYTn4FWagH/Hr2QIk8LOsUz7BIJ4tooFhmx8urHKCdlPbbPDCA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.2.tgz",
+      "integrity": "sha512-6BNfPVp/8gcmkKdJhNJK3HEkUNNTrY3hM9vuWXIUSoLk9FZo1L2QuGLGB6S124D9ySInn8PzEdOtguCF5Ao4KA==",
       "requires": {
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.1.0.tgz",
-      "integrity": "sha512-2G4TlzUnmTrUY26VKTonQqydwb+gtM/mcl+TqDP8CnWtJKVL8ElPpKgLGScP04bPIRY9x2/10lDdoaRXDqPuCw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
+      "integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
       "requires": {
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/shared-ini-file-loader": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/shared-ini-file-loader": "^2.0.11",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
-      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
+      "integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
       "requires": {
-        "@smithy/abort-controller": "^1.1.0",
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/querystring-builder": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/abort-controller": "^2.0.9",
+        "@smithy/protocol-http": "^3.0.5",
+        "@smithy/querystring-builder": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/property-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.2.0.tgz",
-      "integrity": "sha512-qlJd9gT751i4T0t/hJAyNGfESfi08Fek8QiLcysoKPgR05qHhG0OYhlaCJHhpXy4ECW0lHyjvFM1smrCLIXVfw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
+      "integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
-      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
+      "integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
-      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
+      "integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
       "requires": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-uri-escape": "^1.1.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.1.0.tgz",
-      "integrity": "sha512-Lm/FZu2qW3XX+kZ4WPwr+7aAeHf1Lm84UjNkKyBu16XbmEV7ukfhXni2aIwS2rcVf8Yv5E7wchGGpOFldj9V4Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
+      "integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
-      "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
+      "integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
+      "requires": {
+        "@smithy/types": "^2.3.3"
+      }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.1.0.tgz",
-      "integrity": "sha512-S/v33zvCWzFyGZGlsEF0XsZtNNR281UhR7byk3nRfsgw5lGpg51rK/zjMgulM+h6NSuXaFILaYrw1I1v4kMcuA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
+      "integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
       "requires": {
-        "@smithy/types": "^1.2.0",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/signature-v4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.1.0.tgz",
-      "integrity": "sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.9.tgz",
+      "integrity": "sha512-RkHP0joSI1j2EI+mU55sOi33/aMMkKdL9ZY+SWrPxsiCe1oyzzuy79Tpn8X7uT+t0ilNmQlwPpkP/jUy940pEA==",
       "requires": {
-        "@smithy/eventstream-codec": "^1.1.0",
-        "@smithy/is-array-buffer": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
-        "@smithy/util-middleware": "^1.1.0",
-        "@smithy/util-uri-escape": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/eventstream-codec": "^2.0.9",
+        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/smithy-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.1.0.tgz",
-      "integrity": "sha512-j32SGgVhv2G9nBTmel9u3OXux8KG20ssxuFakJrEeDug3kqbl1qrGzVLCe+Eib402UDtA0Sp1a4NZ2SEXDBxag==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.6.tgz",
+      "integrity": "sha512-+F26b8U7C6ydJgj5Y+OZ94NL54HQUPF1LrFiZjMAIX3OlgZjDhiT3m6VOZo6+hge3sEFOrupwdjB5V24JOCpQw==",
       "requires": {
-        "@smithy/middleware-stack": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-stream": "^1.1.0",
+        "@smithy/middleware-stack": "^2.0.2",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-stream": "^2.0.12",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
+      "integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.1.0.tgz",
-      "integrity": "sha512-tpvi761kzboiLNGEWczuybMPCJh6WHB3cz9gWAG95mSyaKXmmX8ZcMxoV+irZfxDqLwZVJ22XTumu32S7Ow8aQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
+      "integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
       "requires": {
-        "@smithy/querystring-parser": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/querystring-parser": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.1.0.tgz",
-      "integrity": "sha512-FpYmDmVbOXAxqvoVCwqehUN0zXS+lN8V7VS9O7I8MKeVHdSTsZzlwiMEvGoyTNOXWn8luF4CTDYgNHnZViR30g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
+      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
       "requires": {
-        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.1.0.tgz",
-      "integrity": "sha512-cep3ioRxzRZ2Jbp3Kly7gy6iNVefYXiT6ETt8W01RQr3uwi1YMkrbU1p3lMR4KhX/91Nrk6UOgX1RH+oIt48RQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
+      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.1.0.tgz",
-      "integrity": "sha512-fRHRjkUuT5em4HZoshySXmB1n3HAU7IS232s+qU4TicexhyGJpXMK/2+c56ePOIa1FOK2tV1Q3J/7Mae35QVSw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
+      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
       "requires": {
-        "@smithy/is-array-buffer": "^1.1.0",
+        "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-config-provider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.1.0.tgz",
-      "integrity": "sha512-rQ47YpNmF6Is4I9GiE3T3+0xQ+r7RKRKbmHYyGSbyep/0cSf9kteKcI0ssJTvveJ1K4QvwrxXj1tEFp/G2UqxQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
+      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.1.0.tgz",
-      "integrity": "sha512-0bWhs1e412bfC5gwPCMe8Zbz0J8UoZ/meEQdo6MYj8Ne+c+QZ+KxVjx0a1dFYOclvM33SslL9dP0odn8kfblkg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.10.tgz",
+      "integrity": "sha512-M5eaPn961jU2glZkqvmrVd6H4Tz4j1CJ2Kt8kjqMfcWZ4IQFgwPYbRkgND0W93dZXDmFU2GtuJGatwSmWIqxrA==",
       "requires": {
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/smithy-client": "^2.1.6",
+        "@smithy/types": "^2.3.3",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.1.0.tgz",
-      "integrity": "sha512-440e25TUH2b+TeK5CwsjYFrI9ShVOgA31CoxCKiv4ncSK4ZM68XW5opYxQmzMbRWARGEMu2XEUeBmOgMU2RLsw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.12.tgz",
+      "integrity": "sha512-fwAVus2YBTU5u4KFmmEZDdgx3HpUUg8f6SEUetJFsNL+6AzoGBIhCZX0yMrVCLJEZe6tUfMbL5TZHXMw2q6MaA==",
       "requires": {
-        "@smithy/config-resolver": "^1.1.0",
-        "@smithy/credential-provider-imds": "^1.1.0",
-        "@smithy/node-config-provider": "^1.1.0",
-        "@smithy/property-provider": "^1.2.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/config-resolver": "^2.0.10",
+        "@smithy/credential-provider-imds": "^2.0.12",
+        "@smithy/node-config-provider": "^2.0.12",
+        "@smithy/property-provider": "^2.0.10",
+        "@smithy/smithy-client": "^2.1.6",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-hex-encoding": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.1.0.tgz",
-      "integrity": "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-middleware": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.1.0.tgz",
-      "integrity": "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
+      "integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
       "requires": {
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-retry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
-      "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
+      "integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
       "requires": {
-        "@smithy/service-error-classification": "^1.1.0",
+        "@smithy/service-error-classification": "^2.0.2",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.1.0.tgz",
-      "integrity": "sha512-w3lsdGsntaLQIrwDWJkIFKrFscgZXwU/oxsse09aSTNv5TckPhDeYea3LhsDrU5MGAG3vprhVZAKr33S45coVA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
+      "integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
       "requires": {
-        "@smithy/fetch-http-handler": "^1.1.0",
-        "@smithy/node-http-handler": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-base64": "^1.1.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "@smithy/util-hex-encoding": "^1.1.0",
-        "@smithy/util-utf8": "^1.1.0",
+        "@smithy/fetch-http-handler": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.5",
+        "@smithy/types": "^2.3.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-uri-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
-      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
+      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
-      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
+      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
       "requires": {
-        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-waiter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.1.0.tgz",
-      "integrity": "sha512-S6FNIB3UJT+5Efd/0DeziO5Rs82QAMODHW4v2V3oNRrwaBigY/7Yx3SiLudZuF9WpVsV08Ih3BjIH34nzZiinQ==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.9.tgz",
+      "integrity": "sha512-Hy9Cs0FtIacC1aVFk98bm/7CYqim9fnHAPRnV/SB2mj02ExYs/9Dn5SrNQmtTBTLCn65KqYnNVBNS8GuGpZOOw==",
       "requires": {
-        "@smithy/abort-controller": "^1.1.0",
-        "@smithy/types": "^1.2.0",
+        "@smithy/abort-controller": "^2.0.9",
+        "@smithy/types": "^2.3.3",
         "tslib": "^2.5.0"
       }
     },
@@ -5983,9 +6013,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7092,9 +7122,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "standard && markdownlint-cli2 '*.md' '**/*.md' '#node_modules'"
   },
   "dependencies": {
-    "@aws-sdk/client-route-53": "^3.377.0",
-    "@aws-sdk/client-ses": "^3.377.0",
+    "@aws-sdk/client-route-53": "^3.414.0",
+    "@aws-sdk/client-ses": "^3.414.0",
     "dotenv": "^16.3.1",
     "log4js": "^6.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
-    "markdownlint-cli2": "^0.8.1",
+    "markdownlint-cli2": "^0.10.0",
     "standard": "^17.1.0"
   }
 }


### PR DESCRIPTION
- chore(deps): bump `aws-sdk` from `3.377.0` to `3.414.0`
- chore(dev-deps): bump `markdownlint-cli2` from `0.8.1` to `0.10.0`