### PR TITLE
chore(deps): bump `aws-sdk` from `3.414.0` to `3.427.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-route-53": "^3.414.0",
-        "@aws-sdk/client-ses": "^3.414.0",
+        "@aws-sdk/client-route-53": "^3.427.0",
+        "@aws-sdk/client-ses": "^3.427.0",
         "dotenv": "^16.3.1",
         "log4js": "^6.9.1"
       },
@@ -114,49 +114,49 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-route-53": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.414.0.tgz",
-      "integrity": "sha512-s0x95gSvOgULLy1fjvjS93D6BytJByCMgFeSWqPrnR+QFyvNkNox0cfMp0bUwqcCd/BE0BHocbEr2NX+uSQWWg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.427.0.tgz",
+      "integrity": "sha512-kmcn+REC/ghri0ikfrhTxqPMVQajUjGYSvvxdZNUdDPvYkn/nCJgVGR+6ua7J731mKrXFUio6OkNQG0okHSTdA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.414.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-sdk-route53": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-route53": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.7",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -165,47 +165,47 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.414.0.tgz",
-      "integrity": "sha512-GD9ZqzjcGk5mkgmhwnEiemyIsLUz7O/SMvwxDo9prSBlrJ0jiVxbr0JbrACfQhn3geD/VIalvHQFDvQ3OVF4wQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.427.0.tgz",
+      "integrity": "sha512-4jZWMiNK3wredVxXGsAt57puuuEYC18AIfaRmm3NRaKdQ3DOOJY6wIB/A5LqfilRPQE2HSNtNk2+dzHKCXa76w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.414.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.7",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -214,42 +214,42 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
-      "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.427.0.tgz",
+      "integrity": "sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -258,45 +258,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
-      "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.427.0.tgz",
+      "integrity": "sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-sdk-sts": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-sts": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
@@ -306,13 +306,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
-      "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.425.0.tgz",
+      "integrity": "sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -320,19 +320,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
-      "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.427.0.tgz",
+      "integrity": "sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.413.0",
-        "@aws-sdk/credential-provider-process": "3.413.0",
-        "@aws-sdk/credential-provider-sso": "3.414.0",
-        "@aws-sdk/credential-provider-web-identity": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -340,20 +340,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
-      "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.427.0.tgz",
+      "integrity": "sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.413.0",
-        "@aws-sdk/credential-provider-ini": "3.414.0",
-        "@aws-sdk/credential-provider-process": "3.413.0",
-        "@aws-sdk/credential-provider-sso": "3.414.0",
-        "@aws-sdk/credential-provider-web-identity": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-ini": "3.427.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -361,14 +361,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
-      "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.425.0.tgz",
+      "integrity": "sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -376,16 +376,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
-      "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.427.0.tgz",
+      "integrity": "sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.414.0",
-        "@aws-sdk/token-providers": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/client-sso": "3.427.0",
+        "@aws-sdk/token-providers": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -393,13 +393,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
-      "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.425.0.tgz",
+      "integrity": "sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
-      "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.425.0.tgz",
+      "integrity": "sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -421,12 +421,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
-      "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.425.0.tgz",
+      "integrity": "sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -434,13 +434,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
-      "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.425.0.tgz",
+      "integrity": "sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -448,12 +448,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-route53": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.413.0.tgz",
-      "integrity": "sha512-PNdR7dZVHQ3ZHB4V7PjGpUz4ecr86BiHHK2c1SmWvjRMX3EEThAWchc8lMMiUuFHcaUd6jsggUNOdiVymVTYTw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.425.0.tgz",
+      "integrity": "sha512-GNMTw6u+dnXAnO8X5CUICYWDIwlNnDLdOpbbz9oejuJPIiL0lnhgTk3dC+Srm+OnXFVGujqzewqb8Zq6CVExkw==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -461,13 +461,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
-      "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.425.0.tgz",
+      "integrity": "sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -475,16 +475,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
-      "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.425.0.tgz",
+      "integrity": "sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/protocol-http": "^3.0.6",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.3.1",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -492,14 +492,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
-      "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.427.0.tgz",
+      "integrity": "sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -507,14 +507,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
-      "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.425.0.tgz",
+      "integrity": "sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/types": "^2.3.1",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -522,43 +522,43 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
-      "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.427.0.tgz",
+      "integrity": "sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/protocol-http": "^3.0.6",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -567,11 +567,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
-      "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.425.0.tgz",
+      "integrity": "sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==",
       "dependencies": {
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -579,11 +579,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
-      "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.427.0.tgz",
+      "integrity": "sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -602,24 +603,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
-      "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.425.0.tgz",
+      "integrity": "sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
-      "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.425.0.tgz",
+      "integrity": "sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==",
       "dependencies": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -778,11 +779,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
-      "integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.11.tgz",
+      "integrity": "sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -790,14 +791,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
-      "integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.14.tgz",
+      "integrity": "sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/types": "^2.3.3",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -805,14 +806,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
-      "integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.16.tgz",
+      "integrity": "sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/types": "^2.3.3",
-        "@smithy/url-parser": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -831,23 +832,23 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
-      "integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.2.tgz",
+      "integrity": "sha512-K7aRtRuaBjzlk+jWWeyfDTLAmRRvmA4fU8eHUXtjsuEDgi3f356ZE32VD2ssxIH13RCLVZbXMt5h7wHzYiSuVA==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/querystring-builder": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
-      "integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.11.tgz",
+      "integrity": "sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -857,11 +858,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
-      "integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz",
+      "integrity": "sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -877,12 +878,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
-      "integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz",
+      "integrity": "sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/types": "^2.3.3",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -890,14 +891,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
-      "integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.11.tgz",
+      "integrity": "sha512-mCugsvB15up6fqpzUEpMT4CuJmFkEI+KcozA7QMzYguXCaIilyMKsyxgamwmr+o7lo3QdjN0//XLQ9bWFL129g==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.9",
-        "@smithy/types": "^2.3.3",
-        "@smithy/url-parser": "^2.0.9",
-        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -905,16 +906,16 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
-      "integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.16.tgz",
+      "integrity": "sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/service-error-classification": "^2.0.2",
-        "@smithy/types": "^2.3.3",
-        "@smithy/util-middleware": "^2.0.2",
-        "@smithy/util-retry": "^2.0.2",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-middleware": "^2.0.4",
+        "@smithy/util-retry": "^2.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -923,11 +924,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
-      "integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz",
+      "integrity": "sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -935,11 +936,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.2.tgz",
-      "integrity": "sha512-6BNfPVp/8gcmkKdJhNJK3HEkUNNTrY3hM9vuWXIUSoLk9FZo1L2QuGLGB6S124D9ySInn8PzEdOtguCF5Ao4KA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz",
+      "integrity": "sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -947,13 +948,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
-      "integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.1.tgz",
+      "integrity": "sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/shared-ini-file-loader": "^2.0.11",
-        "@smithy/types": "^2.3.3",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/shared-ini-file-loader": "^2.2.0",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -961,14 +962,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
-      "integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz",
+      "integrity": "sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.9",
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/querystring-builder": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -976,11 +977,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
-      "integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.12.tgz",
+      "integrity": "sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -988,11 +989,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
-      "integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.7.tgz",
+      "integrity": "sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1000,11 +1001,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
-      "integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz",
+      "integrity": "sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -1013,11 +1014,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
-      "integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz",
+      "integrity": "sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1025,22 +1026,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
-      "integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz",
+      "integrity": "sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==",
       "dependencies": {
-        "@smithy/types": "^2.3.3"
+        "@smithy/types": "^2.3.5"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
-      "integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.0.tgz",
+      "integrity": "sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1066,13 +1067,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.6.tgz",
-      "integrity": "sha512-+F26b8U7C6ydJgj5Y+OZ94NL54HQUPF1LrFiZjMAIX3OlgZjDhiT3m6VOZo6+hge3sEFOrupwdjB5V24JOCpQw==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.10.tgz",
+      "integrity": "sha512-2OEmZDiW1Z196QHuQZ5M6cBE8FCSG0H2HADP1G+DY8P3agsvb0YJyfhyKuJbxIQy15tr3eDAK6FOrlbxgKOOew==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.2",
-        "@smithy/types": "^2.3.3",
-        "@smithy/util-stream": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-stream": "^2.0.15",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1080,9 +1081,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
-      "integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.5.tgz",
+      "integrity": "sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1091,12 +1092,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
-      "integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.11.tgz",
+      "integrity": "sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/querystring-parser": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -1155,13 +1156,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.10.tgz",
-      "integrity": "sha512-M5eaPn961jU2glZkqvmrVd6H4Tz4j1CJ2Kt8kjqMfcWZ4IQFgwPYbRkgND0W93dZXDmFU2GtuJGatwSmWIqxrA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.14.tgz",
+      "integrity": "sha512-NupG7SWUucm3vJrvlpt9jG1XeoPJphjcivgcUUXhDJbUPy4F04LhlTiAhWSzwlCNcF8OJsMvZ/DWbpYD3pselw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/smithy-client": "^2.1.6",
-        "@smithy/types": "^2.3.3",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1170,16 +1171,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.12.tgz",
-      "integrity": "sha512-fwAVus2YBTU5u4KFmmEZDdgx3HpUUg8f6SEUetJFsNL+6AzoGBIhCZX0yMrVCLJEZe6tUfMbL5TZHXMw2q6MaA==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.18.tgz",
+      "integrity": "sha512-+3jMom/b/Cdp21tDnY4vKu249Al+G/P0HbRbct7/aSZDlROzv1tksaYukon6UUv7uoHn+/McqnsvqZHLlqvQ0g==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.10",
-        "@smithy/credential-provider-imds": "^2.0.12",
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/smithy-client": "^2.1.6",
-        "@smithy/types": "^2.3.3",
+        "@smithy/config-resolver": "^2.0.14",
+        "@smithy/credential-provider-imds": "^2.0.16",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1198,11 +1199,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
-      "integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.4.tgz",
+      "integrity": "sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==",
       "dependencies": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1210,12 +1211,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
-      "integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.4.tgz",
+      "integrity": "sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.2",
-        "@smithy/types": "^2.3.3",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1223,13 +1224,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
-      "integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.15.tgz",
+      "integrity": "sha512-A/hkYJPH2N5MCWYvky4tTpQihpYAEzqnUfxDyG3L/yMndy/2sLvxnyQal9Opuj1e9FiKSTeMyjnU9xxZGs0mRw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.5",
-        "@smithy/types": "^2.3.3",
+        "@smithy/fetch-http-handler": "^2.2.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -1264,12 +1265,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.9.tgz",
-      "integrity": "sha512-Hy9Cs0FtIacC1aVFk98bm/7CYqim9fnHAPRnV/SB2mj02ExYs/9Dn5SrNQmtTBTLCn65KqYnNVBNS8GuGpZOOw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.11.tgz",
+      "integrity": "sha512-8SJWUl9O1YhjC77EccgltI3q4XZQp3vp9DGEW6o0OdkUcwqm/H4qOLnMkA2n+NDojuM5Iia2jWoCdbluIiG7TA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4376,416 +4377,417 @@
       }
     },
     "@aws-sdk/client-route-53": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.414.0.tgz",
-      "integrity": "sha512-s0x95gSvOgULLy1fjvjS93D6BytJByCMgFeSWqPrnR+QFyvNkNox0cfMp0bUwqcCd/BE0BHocbEr2NX+uSQWWg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.427.0.tgz",
+      "integrity": "sha512-kmcn+REC/ghri0ikfrhTxqPMVQajUjGYSvvxdZNUdDPvYkn/nCJgVGR+6ua7J731mKrXFUio6OkNQG0okHSTdA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.414.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-sdk-route53": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-route53": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.7",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-ses": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.414.0.tgz",
-      "integrity": "sha512-GD9ZqzjcGk5mkgmhwnEiemyIsLUz7O/SMvwxDo9prSBlrJ0jiVxbr0JbrACfQhn3geD/VIalvHQFDvQ3OVF4wQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.427.0.tgz",
+      "integrity": "sha512-4jZWMiNK3wredVxXGsAt57puuuEYC18AIfaRmm3NRaKdQ3DOOJY6wIB/A5LqfilRPQE2HSNtNk2+dzHKCXa76w==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.414.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.7",
+        "@smithy/util-waiter": "^2.0.10",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.414.0.tgz",
-      "integrity": "sha512-GvRwQ7wA3edzsQEKS70ZPhkOUZ62PAiXasjp6GxrsADEb8sV1z4FxXNl9Un/7fQxKkh9QYaK1Wu1PmhLi9MLMg==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.427.0.tgz",
+      "integrity": "sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.414.0.tgz",
-      "integrity": "sha512-xeYH3si6Imp1EWolWn1zuxJJu2AXKwXl1HDftQULwC5AWkm1mNFbXYSJN4hQul1IM+kn+JTRB0XRHByQkKhe+Q==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.427.0.tgz",
+      "integrity": "sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.414.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-sdk-sts": "3.413.0",
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/region-config-resolver": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-sts": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.413.0.tgz",
-      "integrity": "sha512-yeMOkfG20/RlzfPMtQuDB647AcPEvFEVYOWZzAWVJfldYQ5ybKr0d7sBkgG9sdAzGkK3Aw9dE4rigYI8EIqc1Q==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.425.0.tgz",
+      "integrity": "sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.414.0.tgz",
-      "integrity": "sha512-rlpLLx70roJL/t40opWC96LbIASejdMbRlgSCRpK8b/hKngYDe5A7SRVacaw08vYrAywxRiybxpQOwOt9b++rA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.427.0.tgz",
+      "integrity": "sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.413.0",
-        "@aws-sdk/credential-provider-process": "3.413.0",
-        "@aws-sdk/credential-provider-sso": "3.414.0",
-        "@aws-sdk/credential-provider-web-identity": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.414.0.tgz",
-      "integrity": "sha512-xlkcOUKeGHInxWKKrZKIPSBCUL/ozyCldJBjmMKEj7ZmBAEiDcjpMe3pZ//LibMkCSy0b/7jtyQBE/eaIT2o0A==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.427.0.tgz",
+      "integrity": "sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.413.0",
-        "@aws-sdk/credential-provider-ini": "3.414.0",
-        "@aws-sdk/credential-provider-process": "3.413.0",
-        "@aws-sdk/credential-provider-sso": "3.414.0",
-        "@aws-sdk/credential-provider-web-identity": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-ini": "3.427.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.413.0.tgz",
-      "integrity": "sha512-GFJdgS14GzJ1wc2DEnS44Z/34iBZ05CAkvDsLN2CMwcDgH4eZuif9/x0lwzIJBK3xVFHzYUeVvEzsqRPbCHRsw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.425.0.tgz",
+      "integrity": "sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.414.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.414.0.tgz",
-      "integrity": "sha512-w9g2hlkZn7WekWICRqk+L33py7KrjYMFryVpkKXOx2pjDchCfZDr6pL1ml782GZ0L3qsob4SbNpbtp13JprnWQ==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.427.0.tgz",
+      "integrity": "sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.414.0",
-        "@aws-sdk/token-providers": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/client-sso": "3.427.0",
+        "@aws-sdk/token-providers": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.413.0.tgz",
-      "integrity": "sha512-5cdA1Iq9JeEHtg59ERV9fdMQ7cS0JF6gH/BWA7HYEUGdSVPXCuwyEggPtG64QgpNU7SmxH+QdDG+Ldxz09ycIA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.425.0.tgz",
+      "integrity": "sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.413.0.tgz",
-      "integrity": "sha512-r9PQx468EzPHo9wRzZLfgROpKtVdbkteMrdhsuM12bifVHjU1OHr7yfhc1OdWv39X8Xiv6F8n5r+RBQEM0S6+g==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.425.0.tgz",
+      "integrity": "sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.413.0.tgz",
-      "integrity": "sha512-jqcXDubcKvoqBy+kkEa0WoNjG6SveDeyNy+gdGnTV+DEtYjkcHrHJei4q0W5zFl0mzc+dP+z8tJF44rv95ZY3Q==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.425.0.tgz",
+      "integrity": "sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.413.0.tgz",
-      "integrity": "sha512-C6k0IKJk/A4/VBGwUjxEPG+WOjjnmWAZVRBUzaeM7PqRh+g5rLcuIV356ntV3pREVxyiSTePTYVYIHU9YXkLKQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.425.0.tgz",
+      "integrity": "sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-route53": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.413.0.tgz",
-      "integrity": "sha512-PNdR7dZVHQ3ZHB4V7PjGpUz4ecr86BiHHK2c1SmWvjRMX3EEThAWchc8lMMiUuFHcaUd6jsggUNOdiVymVTYTw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.425.0.tgz",
+      "integrity": "sha512-GNMTw6u+dnXAnO8X5CUICYWDIwlNnDLdOpbbz9oejuJPIiL0lnhgTk3dC+Srm+OnXFVGujqzewqb8Zq6CVExkw==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.413.0.tgz",
-      "integrity": "sha512-t0u//JUyaEZRVnH5q+Ur3tWnuyIsTdwA0XOdDCZXcSlLYzGp2MI/tScLjn9IydRrceIFpFfmbjk4Nf/Q6TeBTQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.425.0.tgz",
+      "integrity": "sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.413.0.tgz",
-      "integrity": "sha512-QFEnVvIKYPCermM+ESxEztgUgXzGSKpnPnohMYNvSZySqmOLu/4VvxiZbRO/BX9J3ZHcUgaw4vKm5VBZRrycxw==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.425.0.tgz",
+      "integrity": "sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/protocol-http": "^3.0.6",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.3.1",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.413.0.tgz",
-      "integrity": "sha512-eVMJyeWxNBqerhfD+sE9sTjDtwQiECrfU6wpUQP5fGPhJD2cVVZPxuTuJGDZCu/4k/V61dF85IYlsPUNLdVQ6w==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.427.0.tgz",
+      "integrity": "sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@smithy/protocol-http": "^3.0.3",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/region-config-resolver": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.413.0.tgz",
-      "integrity": "sha512-h90e6yyOhvoc+1F5vFk3C5mxwB8RSDEMKTO/fxexyur94seczZ1yxyYkTMZv30oc9RUiToABlHNrh/wxL7TZPQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.425.0.tgz",
+      "integrity": "sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/types": "^2.3.1",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.3",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.413.0.tgz",
-      "integrity": "sha512-NfP1Ib9LAWVLMTOa/1aJwt4TRrlRrNyukCpVZGfNaMnNNEoP5Rakdbcs8KFVHe/MJzU+GdKVzxQ4TgRkLOGTrA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.427.0.tgz",
+      "integrity": "sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.413.0",
-        "@aws-sdk/middleware-logger": "3.413.0",
-        "@aws-sdk/middleware-recursion-detection": "3.413.0",
-        "@aws-sdk/middleware-user-agent": "3.413.0",
-        "@aws-sdk/types": "3.413.0",
-        "@aws-sdk/util-endpoints": "3.413.0",
-        "@aws-sdk/util-user-agent-browser": "3.413.0",
-        "@aws-sdk/util-user-agent-node": "3.413.0",
-        "@smithy/config-resolver": "^2.0.8",
-        "@smithy/fetch-http-handler": "^2.1.3",
-        "@smithy/hash-node": "^2.0.7",
-        "@smithy/invalid-dependency": "^2.0.7",
-        "@smithy/middleware-content-length": "^2.0.9",
-        "@smithy/middleware-endpoint": "^2.0.7",
-        "@smithy/middleware-retry": "^2.0.10",
-        "@smithy/middleware-serde": "^2.0.7",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/node-http-handler": "^2.1.3",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/protocol-http": "^3.0.6",
         "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.4",
-        "@smithy/types": "^2.3.1",
-        "@smithy/url-parser": "^2.0.7",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.8",
-        "@smithy/util-defaults-mode-node": "^2.0.10",
-        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.413.0.tgz",
-      "integrity": "sha512-j1xib0f/TazIFc5ySIKOlT1ujntRbaoG4LJFeEezz4ji03/wSJMI8Vi4KjzpBp8J1tTu0oRDnsxRIGixsUBeYQ==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.425.0.tgz",
+      "integrity": "sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==",
       "requires": {
-        "@smithy/types": "^2.3.1",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.413.0.tgz",
-      "integrity": "sha512-VAwr7cITNb1L6/2XUPIbCOuhKGm0VtKCRblurrfUF2bxqG/wtuw/2Fm4ahYJPyxklOSXAMSq+RHdFWcir0YB/g==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.427.0.tgz",
+      "integrity": "sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
         "tslib": "^2.5.0"
       }
     },
@@ -4798,24 +4800,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.413.0.tgz",
-      "integrity": "sha512-7j/qWcRO2OBZBre2fC6V6M0PAS9n7k6i+VtofPkkhxC2DZszLJElqnooF9hGmVGYK3zR47Np4WjURXKIEZclWg==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.425.0.tgz",
+      "integrity": "sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.413.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.413.0.tgz",
-      "integrity": "sha512-vHm9TVZIzfWMeDvdmoOky6VarqOt8Pr68CESHN0jyuO6XbhCDnr9rpaXiBhbSR+N1Qm7R/AfJgAhQyTMu2G1OA==",
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.425.0.tgz",
+      "integrity": "sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==",
       "requires": {
-        "@aws-sdk/types": "3.413.0",
-        "@smithy/node-config-provider": "^2.0.10",
-        "@smithy/types": "^2.3.1",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       }
     },
@@ -4923,35 +4925,35 @@
       }
     },
     "@smithy/abort-controller": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.9.tgz",
-      "integrity": "sha512-8liHOEbx99xcy4VndeQNQhyA0LS+e7UqsuRnDTSIA26IKBv/7vA9w09KOd4fgNULrvX0r3WpA6cwsQTRJpSWkg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.11.tgz",
+      "integrity": "sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.10.tgz",
-      "integrity": "sha512-MwToDsCltHjumkCuRn883qoNeJUawc2b8sX9caSn5vLz6J5crU1IklklNxWCaMO2z2nDL91Po4b/aI1eHv5PfA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.14.tgz",
+      "integrity": "sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/types": "^2.3.3",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.12.tgz",
-      "integrity": "sha512-S3lUNe+2fEFwKcmiQniXGPXt69vaHvQCw8kYQOBL4OvJsgwfpkIYDZdroHbTshYi0M6WaKL26Mw+hvgma6dZqA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.16.tgz",
+      "integrity": "sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/types": "^2.3.3",
-        "@smithy/url-parser": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
         "tslib": "^2.5.0"
       }
     },
@@ -4967,34 +4969,34 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.5.tgz",
-      "integrity": "sha512-BIeCHGfr5JCGN+EMTwZK74ELvjPXOIrI7OLM5OhZJJ6AmZyRv2S9ANJk18AtLwht0TsSm+8WoXIEp8LuxNgUyA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.2.tgz",
+      "integrity": "sha512-K7aRtRuaBjzlk+jWWeyfDTLAmRRvmA4fU8eHUXtjsuEDgi3f356ZE32VD2ssxIH13RCLVZbXMt5h7wHzYiSuVA==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/querystring-builder": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-node": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.9.tgz",
-      "integrity": "sha512-XP3yWd5wyCtiVmsY5Nuq/FUwyCEQ6YG7DsvRh7ThldNukGpCzyFdP8eivZJVjn4Fx7oYrrOnVoYZ0WEgpW1AvQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.11.tgz",
+      "integrity": "sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.9.tgz",
-      "integrity": "sha512-RuJqhYf8nViK96IIO9JbTtjDUuFItVfuuJhWw2yk7fv67yltQ7fZD6IQ2OsHHluoVmstnQJuCg5raXJR696Ubw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz",
+      "integrity": "sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -5007,134 +5009,134 @@
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.11.tgz",
-      "integrity": "sha512-Malj4voNTL4+a5ZL3a6+Ij7JTUMTa2R7c3ZIBzMxN5OUUgAspU7uFi1Q97f4B0afVh2joQBAWH5IQJUG25nl8g==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz",
+      "integrity": "sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/types": "^2.3.3",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.9.tgz",
-      "integrity": "sha512-72/o8R6AAO4+nyTI6h4z6PYGTSA4dr1M7tZz29U8DEUHuh1YkhC77js0P6RyF9G0wDLuYqxb+Yh0crI5WG2pJg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.11.tgz",
+      "integrity": "sha512-mCugsvB15up6fqpzUEpMT4CuJmFkEI+KcozA7QMzYguXCaIilyMKsyxgamwmr+o7lo3QdjN0//XLQ9bWFL129g==",
       "requires": {
-        "@smithy/middleware-serde": "^2.0.9",
-        "@smithy/types": "^2.3.3",
-        "@smithy/url-parser": "^2.0.9",
-        "@smithy/util-middleware": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.11",
+        "@smithy/types": "^2.3.5",
+        "@smithy/url-parser": "^2.0.11",
+        "@smithy/util-middleware": "^2.0.4",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.12.tgz",
-      "integrity": "sha512-YQ/ufXX4/d9/+Jf1QQ4J+CVeupC7BW52qldBTvRV33PDX9vxndlAwkFwzBcmnUFC3Hjf1//HW6I77EItcjNSCA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.16.tgz",
+      "integrity": "sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/service-error-classification": "^2.0.2",
-        "@smithy/types": "^2.3.3",
-        "@smithy/util-middleware": "^2.0.2",
-        "@smithy/util-retry": "^2.0.2",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-middleware": "^2.0.4",
+        "@smithy/util-retry": "^2.0.4",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.9.tgz",
-      "integrity": "sha512-GVbauxrr6WmtCaesakktg3t5LR/yDbajpC7KkWc8rtCpddMI4ShAVO5Q6DqwX8MDFi4CLaY8H7eTGcxhl3jbLg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz",
+      "integrity": "sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.2.tgz",
-      "integrity": "sha512-6BNfPVp/8gcmkKdJhNJK3HEkUNNTrY3hM9vuWXIUSoLk9FZo1L2QuGLGB6S124D9ySInn8PzEdOtguCF5Ao4KA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz",
+      "integrity": "sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.12.tgz",
-      "integrity": "sha512-df9y9ywv+JmS40Y60ZqJ4jfZiTCmyHQffwzIqjBjLJLJl0imf9F6DWBd+jiEWHvlohR+sFhyY+KL/qzKgnAq1A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.1.tgz",
+      "integrity": "sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==",
       "requires": {
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/shared-ini-file-loader": "^2.0.11",
-        "@smithy/types": "^2.3.3",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/shared-ini-file-loader": "^2.2.0",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.5.tgz",
-      "integrity": "sha512-52uF+BrZaFiBh+NT/bADiVDCQO91T+OwDRsuaAeWZC1mlCXFjAPPQdxeQohtuYOe9m7mPP/xIMNiqbe8jvndHA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz",
+      "integrity": "sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.9",
-        "@smithy/protocol-http": "^3.0.5",
-        "@smithy/querystring-builder": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/protocol-http": "^3.0.7",
+        "@smithy/querystring-builder": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/property-provider": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.10.tgz",
-      "integrity": "sha512-YMBVfh0ZMmJtbsUn+WfSwR32iRljZPdRN0Tn2GAcdJ+ejX8WrBXD7Z0jIkQDrQZr8fEuuv5x8WxMIj+qVbsPQw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.12.tgz",
+      "integrity": "sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.5.tgz",
-      "integrity": "sha512-3t3fxj+ip4EPHRC2fQ0JimMxR/qCQ1LSQJjZZVZFgROnFLYWPDgUZqpoi7chr+EzatxJVXF/Rtoi5yLHOWCoZQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.7.tgz",
+      "integrity": "sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.9.tgz",
-      "integrity": "sha512-Yt6CPF4j3j1cuwod/DRflbuXxBFjJm7gAjy6W1RE21Rz5/kfGFqiZBXWmmXwGtnnhiLThYwoHK4S6/TQtnx0Fg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz",
+      "integrity": "sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.9.tgz",
-      "integrity": "sha512-U6z4N743s4vrcxPW8p8+reLV0PjMCYEyb1/wtMVvv3VnbJ74gshdI8SR1sBnEh95cF8TxonmX5IxY25tS9qGfg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz",
+      "integrity": "sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.2.tgz",
-      "integrity": "sha512-GTUd2j63gKy7A+ggvSdn2hc4sejG7LWfE+ZMF17vzWoNyqERWbRP7HTPS0d0Lwg1p6OQCAzvNigSrEIWVFt6iA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz",
+      "integrity": "sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==",
       "requires": {
-        "@smithy/types": "^2.3.3"
+        "@smithy/types": "^2.3.5"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.11.tgz",
-      "integrity": "sha512-Sf0u5C5px6eykXi6jImDTp+edvG3REtPjXnFWU/J+b7S2wkXwUqFXqBL5DdM4zC1F+M8u57ZT7NRqDwMOw7/Tw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.0.tgz",
+      "integrity": "sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -5154,31 +5156,31 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.6.tgz",
-      "integrity": "sha512-+F26b8U7C6ydJgj5Y+OZ94NL54HQUPF1LrFiZjMAIX3OlgZjDhiT3m6VOZo6+hge3sEFOrupwdjB5V24JOCpQw==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.10.tgz",
+      "integrity": "sha512-2OEmZDiW1Z196QHuQZ5M6cBE8FCSG0H2HADP1G+DY8P3agsvb0YJyfhyKuJbxIQy15tr3eDAK6FOrlbxgKOOew==",
       "requires": {
-        "@smithy/middleware-stack": "^2.0.2",
-        "@smithy/types": "^2.3.3",
-        "@smithy/util-stream": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.5",
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-stream": "^2.0.15",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.3.tgz",
-      "integrity": "sha512-zTdIPR9PvFVNRdIKMQu4M5oyTaycIbUqLheQqaOi9rTWPkgjGO2wDBxMA1rBHQB81aqAEv+DbSS4jfKyQMnXRA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.5.tgz",
+      "integrity": "sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.9.tgz",
-      "integrity": "sha512-NBnJ0NiY8z6E82Xd5VYUFQfKwK/wA/+QkKmpYUYP+cpH3aCzE6g2gvixd9vQKYjsIdRfNPCf+SFAozt8ljozOw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.11.tgz",
+      "integrity": "sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==",
       "requires": {
-        "@smithy/querystring-parser": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/querystring-parser": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -5225,28 +5227,28 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.10.tgz",
-      "integrity": "sha512-M5eaPn961jU2glZkqvmrVd6H4Tz4j1CJ2Kt8kjqMfcWZ4IQFgwPYbRkgND0W93dZXDmFU2GtuJGatwSmWIqxrA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.14.tgz",
+      "integrity": "sha512-NupG7SWUucm3vJrvlpt9jG1XeoPJphjcivgcUUXhDJbUPy4F04LhlTiAhWSzwlCNcF8OJsMvZ/DWbpYD3pselw==",
       "requires": {
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/smithy-client": "^2.1.6",
-        "@smithy/types": "^2.3.3",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.12.tgz",
-      "integrity": "sha512-fwAVus2YBTU5u4KFmmEZDdgx3HpUUg8f6SEUetJFsNL+6AzoGBIhCZX0yMrVCLJEZe6tUfMbL5TZHXMw2q6MaA==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.18.tgz",
+      "integrity": "sha512-+3jMom/b/Cdp21tDnY4vKu249Al+G/P0HbRbct7/aSZDlROzv1tksaYukon6UUv7uoHn+/McqnsvqZHLlqvQ0g==",
       "requires": {
-        "@smithy/config-resolver": "^2.0.10",
-        "@smithy/credential-provider-imds": "^2.0.12",
-        "@smithy/node-config-provider": "^2.0.12",
-        "@smithy/property-provider": "^2.0.10",
-        "@smithy/smithy-client": "^2.1.6",
-        "@smithy/types": "^2.3.3",
+        "@smithy/config-resolver": "^2.0.14",
+        "@smithy/credential-provider-imds": "^2.0.16",
+        "@smithy/node-config-provider": "^2.1.1",
+        "@smithy/property-provider": "^2.0.12",
+        "@smithy/smithy-client": "^2.1.10",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
@@ -5259,32 +5261,32 @@
       }
     },
     "@smithy/util-middleware": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.2.tgz",
-      "integrity": "sha512-UGPZM+Ja/vke5pc/S8G0LNiHpVirtjppsXO+GK9m9wbzRGzPJTfnZA/gERUUN/AfxEy/8SL7U1kd7u4t2X8K1w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.4.tgz",
+      "integrity": "sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==",
       "requires": {
-        "@smithy/types": "^2.3.3",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-retry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.2.tgz",
-      "integrity": "sha512-ovWiayUB38moZcLhSFFfUgB2IMb7R1JfojU20qSahjxAgfOZvDWme3eOYUMtAVnouZ9kYJiFgHLy27qRH4NeeA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.4.tgz",
+      "integrity": "sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==",
       "requires": {
-        "@smithy/service-error-classification": "^2.0.2",
-        "@smithy/types": "^2.3.3",
+        "@smithy/service-error-classification": "^2.0.4",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-stream": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.12.tgz",
-      "integrity": "sha512-FOCpRLaj6gvSyUC5mJAACT+sPMPmp9sD1o+hVbUH/QxwZfulypA3ZIFdAg/59/IY0d/1Q4CTztsiHEB5LgjN4g==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.15.tgz",
+      "integrity": "sha512-A/hkYJPH2N5MCWYvky4tTpQihpYAEzqnUfxDyG3L/yMndy/2sLvxnyQal9Opuj1e9FiKSTeMyjnU9xxZGs0mRw==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.1.5",
-        "@smithy/node-http-handler": "^2.1.5",
-        "@smithy/types": "^2.3.3",
+        "@smithy/fetch-http-handler": "^2.2.2",
+        "@smithy/node-http-handler": "^2.1.7",
+        "@smithy/types": "^2.3.5",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -5310,12 +5312,12 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.9.tgz",
-      "integrity": "sha512-Hy9Cs0FtIacC1aVFk98bm/7CYqim9fnHAPRnV/SB2mj02ExYs/9Dn5SrNQmtTBTLCn65KqYnNVBNS8GuGpZOOw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.11.tgz",
+      "integrity": "sha512-8SJWUl9O1YhjC77EccgltI3q4XZQp3vp9DGEW6o0OdkUcwqm/H4qOLnMkA2n+NDojuM5Iia2jWoCdbluIiG7TA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.9",
-        "@smithy/types": "^2.3.3",
+        "@smithy/abort-controller": "^2.0.11",
+        "@smithy/types": "^2.3.5",
         "tslib": "^2.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "standard && markdownlint-cli2 '*.md' '**/*.md' '#node_modules'"
   },
   "dependencies": {
-    "@aws-sdk/client-route-53": "^3.414.0",
-    "@aws-sdk/client-ses": "^3.414.0",
+    "@aws-sdk/client-route-53": "^3.427.0",
+    "@aws-sdk/client-ses": "^3.427.0",
     "dotenv": "^16.3.1",
     "log4js": "^6.9.1"
   },


### PR DESCRIPTION
Update `aws-sdk` node dependencies for Route 53 and SES from `3.414.0` to latest release `3.427.0`.