### PR TITLE
chore(node): upgrade to node 20.9.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Set version of node to use
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.18
+          node-version: 20.9
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Set version of node to use
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.18
+          node-version: 20.9
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:18.18.0-alpine3.18
+FROM node:20.9.0-alpine3.18
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE


### PR DESCRIPTION
Node 20 where released as LTS earlier this year and we should upgrade the Docker image and Github actions to use it. This PR also mitigate security issues[ #225](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/225) [#226](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/226) [#227](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/227) and [#228](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/228)