### PR TITLE
fix(node): require at least node engine v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "log4js": "^6.9.1"
   },
   "engines": {
-    "node": "^18.14"
+    "node": ">=18"
   },
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Resolves docker build issue introduced in #53 