### PR TITLE
fix(build): downgrade node from v20 to v18 to fix hanging docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Set version of node to use
-      - name: Use Node.js 20
+      - name: Use Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9
+          node-version: 18.8
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Set version of node to use
-      - name: Use Node.js 20
+      - name: Use Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9
+          node-version: 18.8
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:20.9.0-alpine3.18
+FROM node:18.18.2-alpine3.18
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "standard": "^17.1.0"
       },
       "engines": {
-        "node": "^18.14"
+        "node": ">=18"
       }
     },
     "node_modules/@aws-crypto/crc32": {


### PR DESCRIPTION
Revert upgrading node to v20 since docker build is hanging for more than 1 hour for some reason. We probably need to invest more time for this migration. Upgrading node to latest v18