### PR TITLE
Upgrade node from v18 to v20

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,6 +68,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Set version of node to use
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18.8
+          node-version: 20.x
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,
@@ -89,7 +89,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           tags: |
             sjmayotte/route53-dynamic-dns:${{ steps.vars.outputs.tag }}
             sjmayotte/route53-dynamic-dns:latest
@@ -106,7 +106,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           tags: sjmayotte/route53-dynamic-dns:${{ steps.vars.outputs.tag }}
           build-args: |
             GIT_SHA=$GITHUB_SHA

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Checkout code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set version of node to use
       - name: Use Node.js 18
@@ -52,7 +52,7 @@ jobs:
     steps:
       # Checkout code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set tag to release version tag if one is present (in format v.1.0.0)
       # otherwise consider this a dev build
@@ -128,7 +128,7 @@ jobs:
     steps:
       # Checkout code
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # Number of commits to fetch. 0 indicates all history for all branches and tags.
         # Required for https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/index.html
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,7 +83,7 @@ jobs:
       # If release tag in format (v1.0.0) tag container with
       # git tag and also tag with latest
       - name: Build & Push Container for Release Version & Latest Tag
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: ${{ startsWith(steps.vars.outputs.tag, 'v') }}
         with:
           context: .
@@ -100,7 +100,7 @@ jobs:
 
       # Tag container for non release versions
       - name: Build & Push Container for Dev Tag
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: ${{ startsWith(steps.vars.outputs.tag, 'v') == false }}
         with:
           context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,15 +62,15 @@ jobs:
 
       # Setup QEMU for building various versions of container
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # Setup Buildx before building container
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Login to DockerHub
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -66,6 +66,6 @@ jobs:
 
         # Upload results to the Security tab
       - name: Upload OSSAR results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Set version of node to use
-      - name: Use Node.js 18
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18.8
+          node-version: 20.x
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Checkout code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set version of node to use
       - name: Use Node.js 18

--- a/.github/workflows/snyk_container-analysis.yml
+++ b/.github/workflows/snyk_container-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build a Docker image
         run: docker build -t sjmayotte/route53-dynamic-dns .
       - name: Run Snyk to check Docker image for vulnerabilities

--- a/.github/workflows/snyk_container-analysis.yml
+++ b/.github/workflows/snyk_container-analysis.yml
@@ -56,6 +56,6 @@ jobs:
           image: sjmayotte/route53-dynamic-dns
           args: --file=Dockerfile
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:18.18.2-alpine3.18
+FROM node:20.11.0-bookworm-slim
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE
@@ -10,7 +10,7 @@ ARG GIT_SHA
 ENV NODE_ENV production
 
 # Install timezone database to allow setting timezone through TZ environment variable
-RUN apk add --no-cache tzdata
+RUN apt install tzdata
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
   org.opencontainers.image.authors="Steven Mayotte" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-route-53": "^3.438.0",
-        "@aws-sdk/client-ses": "^3.438.0",
-        "dotenv": "^16.3.1",
+        "@aws-sdk/client-route-53": "^3.515.0",
+        "@aws-sdk/client-ses": "^3.515.0",
+        "dotenv": "^16.4.4",
         "log4js": "^6.9.1"
       },
       "devDependencies": {
-        "markdownlint-cli2": "^0.10.0",
+        "markdownlint-cli2": "^0.12.1",
         "standard": "^17.1.0"
       },
       "engines": {
@@ -114,51 +114,52 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-route-53": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.438.0.tgz",
-      "integrity": "sha512-EgfLLwga39NQ5Uf8gNm0mAzhB2s7dxbeuhNMKuPC8uhasub1ZTlCTW8nZq9sxHiaZlrmrt9cEudcoJCXF7MB1w==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.515.0.tgz",
+      "integrity": "sha512-KNo4PhNDoBSeVN+rhXRKr+oAeepsFna58ijT0fN3iR9Dyi+rENDeSl2H3rKXWRLhCSvR5zgTEnC2JCuakrOG3g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-route53": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-sdk-route53": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@aws-sdk/xml-builder": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-waiter": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -167,49 +168,50 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.438.0.tgz",
-      "integrity": "sha512-F7eFtkZ6eYy1nrGhjg+2n9ZgatBaSxk3DaqjACjDRiIfXNOslbE+yDBinnR4HoI64aqzmE+9P1eddVLtj6UkiQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.515.0.tgz",
+      "integrity": "sha512-X51TvcpqJ83ZOSUa/efWl+cj3cXBF6fCb2iNghjRD2McDvzGKoiR+Zaoy05doPdh/GZ7azTBqX0qKRIyUj//wg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-waiter": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -218,120 +220,200 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.438.0.tgz",
-      "integrity": "sha512-L/xKq+K78PShLku8x5gM6lZDUp7LhFJ2ksKH7Vll+exSZq+QUaxuzjp4gqdzh6B0oIshv2jssQlUa0ScOmVRMg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+      "integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.438.0.tgz",
-      "integrity": "sha512-UBxLZKVVvbR4LHwSNSqaKx22YBSOGkavrh4SyDP8o8XOlXeRxTCllfSfjL9K5Mktp+ZwQ2NiubNcwmvUcGKbbg==",
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+      "integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+      "integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.436.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.436.0.tgz",
-      "integrity": "sha512-vX5/LjXvCejC2XUY6TSg1oozjqK6BvkE75t0ys9dgqyr5PlZyZksMoeAFHUlj0sCjhT3ziWCujP1oiSpPWY9hg==",
+      "version": "3.513.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+      "integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.12"
+        "@smithy/core": "^1.3.2",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+      "integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+      "integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -339,19 +421,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.438.0.tgz",
-      "integrity": "sha512-WYPQR3pXoHJjn9/RMWipUhsUNFy6zhOiII6u8LJ5w84aNqIjV4+BdRYztRNGJD98jdtekhbkX0YKoSuZqP+unQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+      "integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -359,20 +442,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.438.0.tgz",
-      "integrity": "sha512-uaw3D2R0svyrC32qyZ2aOv/l0AT9eClh+eQsZJTQD3Kz9q+2VdeOBThQ8fsMfRtm26nUbZo6A/CRwxkm6okI+w==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+      "integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.438.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-http": "3.515.0",
+        "@aws-sdk/credential-provider-ini": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -380,14 +464,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+      "integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -395,16 +479,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.438.0.tgz",
-      "integrity": "sha512-Xykli/64xR18cBV5P0XFxcH120omtfAjC/cFy/9nFU/+dPvbk0uu1yEOZYteWHyGGkPN4PkHmbh60GiUCLQkWQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+      "integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.438.0",
-        "@aws-sdk/token-providers": "3.438.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sso": "3.515.0",
+        "@aws-sdk/token-providers": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -412,13 +496,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+      "integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -426,13 +511,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+      "integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -440,12 +525,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+      "integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -453,13 +538,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+      "integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -467,43 +552,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-route53": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.433.0.tgz",
-      "integrity": "sha512-bQ/dNrpWN1Zwc4hJ8FneYmo164WqXrbJTzaCwVvHbhlwc9q7tQ8ElYUpodxVJ7aHCvX4NaVI6FJLtd7AynENnA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.515.0.tgz",
+      "integrity": "sha512-OGkxqQeksvjrsn2Qcn0Zom+9LlXjiQJkwJGnVV3U/jzGDgPYh2of5sLlpG86ntGrAsMpjopuOnTbJ0PINtMZqg==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -511,14 +565,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.438.0.tgz",
-      "integrity": "sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+      "integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -526,14 +580,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+      "integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -541,46 +596,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.438.0.tgz",
-      "integrity": "sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+      "integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/client-sso-oidc": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -588,11 +612,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -600,12 +624,13 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.438.0.tgz",
-      "integrity": "sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+      "integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/util-endpoints": "^1.0.2",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -624,24 +649,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+      "integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
-      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+      "integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -665,10 +690,11 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
-      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.496.0.tgz",
+      "integrity": "sha512-GvEjh537IIeOw1ZkZuB37sV12u+ipS5Z1dwjEC/HAvhl5ac23ULtTr1/n+U1gLNN+BAKSWjKiQ2ksj8DiUzeyw==",
       "dependencies": {
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -799,12 +825,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
+      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -812,14 +850,32 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -827,14 +883,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -842,36 +898,36 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -879,18 +935,18 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -899,12 +955,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -912,16 +968,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -929,16 +985,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -947,11 +1004,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -959,11 +1016,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -971,13 +1028,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -985,14 +1042,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1000,11 +1057,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1012,11 +1069,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1024,12 +1081,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1037,11 +1094,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1049,22 +1106,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0"
+        "@smithy/types": "^2.9.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1072,17 +1129,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1090,13 +1147,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1104,9 +1163,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1115,21 +1174,21 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1137,17 +1196,17 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1156,11 +1215,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1168,9 +1227,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1179,13 +1238,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -1194,16 +1253,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/credential-provider-imds": "^2.0.18",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1211,12 +1270,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
-      "integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1224,9 +1283,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1235,11 +1294,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1247,12 +1306,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1260,17 +1319,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1278,9 +1337,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1289,11 +1348,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1301,12 +1360,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
-      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+      "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1645,18 +1704,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1670,20 +1717,20 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
+      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -2279,9 +2326,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2572,19 +2619,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
+      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
       "dev": true,
       "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^1.0.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3054,6 +3102,12 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3089,12 +3143,12 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/load-json-file": {
@@ -3183,54 +3237,59 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
-      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.0.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.31.1.tgz",
-      "integrity": "sha512-CKMR2hgcIBrYlIUccDCOvi966PZ0kJExDrUi1R+oF9PvqQmCrTqjOsgIvf2403OmJ+CWomuzDoylr6KbuMyvHA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.33.0.tgz",
+      "integrity": "sha512-4lbtT14A3m0LPX1WS/3d1m7Blg+ZwiLq36WvjQqFGsX3Gik99NV+VXp/PW3n+Q62xyPdbvGOCfjPqjW+/SKMig==",
       "dev": true,
       "dependencies": {
-        "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.7"
+        "markdown-it": "14.0.0",
+        "markdownlint-micromark": "0.1.8"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.10.0.tgz",
-      "integrity": "sha512-kVxjPyKFC+eW7iqcxiNI50RDzwugpXkEX5eQlDso/0IUs9M73jXYguLFHDzgi5KatcxU/57Fu8KoGtkFft9lfA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.12.1.tgz",
+      "integrity": "sha512-RcK+l5FjJEyrU3REhrThiEUXNK89dLYNJCYbvOUKypxqIGfkcgpz8g08EKqhrmUbYfYoLC5nEYQy53NhJSEtfQ==",
       "dev": true,
       "dependencies": {
-        "globby": "13.2.2",
-        "markdownlint": "0.31.1",
+        "globby": "14.0.0",
+        "jsonc-parser": "3.2.0",
+        "markdownlint": "0.33.0",
         "markdownlint-cli2-formatter-default": "0.0.4",
         "micromatch": "4.0.5",
-        "strip-json-comments": "5.0.1",
-        "yaml": "2.3.2"
+        "yaml": "2.3.4"
       },
       "bin": {
-        "markdownlint-cli2": "markdownlint-cli2.js",
-        "markdownlint-cli2-config": "markdownlint-cli2-config.js",
-        "markdownlint-cli2-fix": "markdownlint-cli2-fix.js"
+        "markdownlint-cli2": "markdownlint-cli2.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2-formatter-default": {
@@ -3242,31 +3301,22 @@
         "markdownlint-cli2": ">=0.0.4"
       }
     },
-    "node_modules/markdownlint-cli2/node_modules/strip-json-comments": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
-      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/markdownlint-micromark": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
-      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.8.tgz",
+      "integrity": "sha512-1ouYkMRo9/6gou9gObuMDnvZM8jC/ly3QCFQyoSPCS2XV1ZClU0xpKbL1Ar3bWWRT1RnBZkWUEiNKrI2CwiBQA==",
       "dev": true,
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "node_modules/merge2": {
@@ -3553,12 +3603,15 @@
       "dev": true
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picomatch": {
@@ -3680,6 +3733,15 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3878,12 +3940,12 @@
       }
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4151,9 +4213,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.0.0.tgz",
+      "integrity": "sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
@@ -4169,6 +4231,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universalify": {
@@ -4287,9 +4361,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -4413,435 +4487,454 @@
       }
     },
     "@aws-sdk/client-route-53": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.438.0.tgz",
-      "integrity": "sha512-EgfLLwga39NQ5Uf8gNm0mAzhB2s7dxbeuhNMKuPC8uhasub1ZTlCTW8nZq9sxHiaZlrmrt9cEudcoJCXF7MB1w==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.515.0.tgz",
+      "integrity": "sha512-KNo4PhNDoBSeVN+rhXRKr+oAeepsFna58ijT0fN3iR9Dyi+rENDeSl2H3rKXWRLhCSvR5zgTEnC2JCuakrOG3g==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-route53": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-sdk-route53": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@aws-sdk/xml-builder": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-waiter": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-ses": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.438.0.tgz",
-      "integrity": "sha512-F7eFtkZ6eYy1nrGhjg+2n9ZgatBaSxk3DaqjACjDRiIfXNOslbE+yDBinnR4HoI64aqzmE+9P1eddVLtj6UkiQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.515.0.tgz",
+      "integrity": "sha512-X51TvcpqJ83ZOSUa/efWl+cj3cXBF6fCb2iNghjRD2McDvzGKoiR+Zaoy05doPdh/GZ7azTBqX0qKRIyUj//wg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.12",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-waiter": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.438.0.tgz",
-      "integrity": "sha512-L/xKq+K78PShLku8x5gM6lZDUp7LhFJ2ksKH7Vll+exSZq+QUaxuzjp4gqdzh6B0oIshv2jssQlUa0ScOmVRMg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+      "integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+      "integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.438.0.tgz",
-      "integrity": "sha512-UBxLZKVVvbR4LHwSNSqaKx22YBSOGkavrh4SyDP8o8XOlXeRxTCllfSfjL9K5Mktp+ZwQ2NiubNcwmvUcGKbbg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+      "integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/core": {
-      "version": "3.436.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.436.0.tgz",
-      "integrity": "sha512-vX5/LjXvCejC2XUY6TSg1oozjqK6BvkE75t0ys9dgqyr5PlZyZksMoeAFHUlj0sCjhT3ziWCujP1oiSpPWY9hg==",
+      "version": "3.513.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+      "integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
       "requires": {
-        "@smithy/smithy-client": "^2.1.12"
+        "@smithy/core": "^1.3.2",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+      "integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+      "integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
+      "requires": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.438.0.tgz",
-      "integrity": "sha512-WYPQR3pXoHJjn9/RMWipUhsUNFy6zhOiII6u8LJ5w84aNqIjV4+BdRYztRNGJD98jdtekhbkX0YKoSuZqP+unQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+      "integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.438.0.tgz",
-      "integrity": "sha512-uaw3D2R0svyrC32qyZ2aOv/l0AT9eClh+eQsZJTQD3Kz9q+2VdeOBThQ8fsMfRtm26nUbZo6A/CRwxkm6okI+w==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+      "integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.438.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-http": "3.515.0",
+        "@aws-sdk/credential-provider-ini": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+      "integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.438.0.tgz",
-      "integrity": "sha512-Xykli/64xR18cBV5P0XFxcH120omtfAjC/cFy/9nFU/+dPvbk0uu1yEOZYteWHyGGkPN4PkHmbh60GiUCLQkWQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+      "integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
       "requires": {
-        "@aws-sdk/client-sso": "3.438.0",
-        "@aws-sdk/token-providers": "3.438.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sso": "3.515.0",
+        "@aws-sdk/token-providers": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+      "integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+      "integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+      "integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+      "integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-route53": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.433.0.tgz",
-      "integrity": "sha512-bQ/dNrpWN1Zwc4hJ8FneYmo164WqXrbJTzaCwVvHbhlwc9q7tQ8ElYUpodxVJ7aHCvX4NaVI6FJLtd7AynENnA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.515.0.tgz",
+      "integrity": "sha512-OGkxqQeksvjrsn2Qcn0Zom+9LlXjiQJkwJGnVV3U/jzGDgPYh2of5sLlpG86ntGrAsMpjopuOnTbJ0PINtMZqg==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
-      "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.438.0.tgz",
-      "integrity": "sha512-a+xHT1wOxT6EA6YyLmrfaroKWOkwwyiktUfXKM0FsUutGzNi4fKhb5NZ2al58NsXzHgHFrasSDp+Lqbd/X2cEw==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+      "integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+      "integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.438.0.tgz",
-      "integrity": "sha512-G2fUfTtU6/1ayYRMu0Pd9Ln4qYSvwJOWCqJMdkDgvXSwdgcOSOLsnAIk1AHGJDAvgLikdCzuyOsdJiexr9Vnww==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+      "integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
       "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-endpoints": "^1.0.2",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
+        "@aws-sdk/client-sso-oidc": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.438.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.438.0.tgz",
-      "integrity": "sha512-6VyPTq1kN3GWxwFt5DdZfOsr6cJZPLjWh0troY/0uUv3hK74C9o3Y0Xf/z8UAUvQFkVqZse12O0/BgPVMImvfA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+      "integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/util-endpoints": "^1.0.2",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4854,24 +4947,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+      "integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.437.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.437.0.tgz",
-      "integrity": "sha512-JVEcvWaniamtYVPem4UthtCNoTBCfFTwYj7Y3CrWZ2Qic4TqrwLkAfaBGtI2TGrhIClVr77uzLI6exqMTN7orA==",
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+      "integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
       "requires": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4884,10 +4977,11 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
-      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.496.0.tgz",
+      "integrity": "sha512-GvEjh537IIeOw1ZkZuB37sV12u+ipS5Z1dwjEC/HAvhl5ac23ULtTr1/n+U1gLNN+BAKSWjKiQ2ksj8DiUzeyw==",
       "requires": {
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4978,412 +5072,436 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sindresorhus/merge-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
+      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "dev": true
+    },
     "@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "requires": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "requires": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "requires": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "requires": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "requires": {
-        "@smithy/types": "^2.4.0"
+        "@smithy/types": "^2.9.1"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/signature-v4": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "requires": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "requires": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-base64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "requires": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "requires": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
       "requires": {
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/credential-provider-imds": "^2.0.18",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-endpoints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
-      "integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "requires": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-stream": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-waiter": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.12.tgz",
-      "integrity": "sha512-3sENmyVa1NnOPoiT2NCApPmu7ukP7S/v7kL9IxNmnygkDldn7/yK0TP42oPJLwB2k3mospNsSePIlqdXEUyPHA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+      "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -5632,15 +5750,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "requires": {
-        "path-type": "^4.0.0"
-      }
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -5651,14 +5760,14 @@
       }
     },
     "dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+      "version": "16.4.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.4.tgz",
+      "integrity": "sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg=="
     },
     "entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
     },
     "error-ex": {
@@ -6081,9 +6190,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6294,16 +6403,17 @@
       }
     },
     "globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
+      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
       "dev": true,
       "requires": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^1.0.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       }
     },
     "gopd": {
@@ -6635,6 +6745,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6664,12 +6780,12 @@
       }
     },
     "linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "requires": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "load-json-file": {
@@ -6739,48 +6855,41 @@
       }
     },
     "markdown-it": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
-      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.0.0"
       }
     },
     "markdownlint": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.31.1.tgz",
-      "integrity": "sha512-CKMR2hgcIBrYlIUccDCOvi966PZ0kJExDrUi1R+oF9PvqQmCrTqjOsgIvf2403OmJ+CWomuzDoylr6KbuMyvHA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.33.0.tgz",
+      "integrity": "sha512-4lbtT14A3m0LPX1WS/3d1m7Blg+ZwiLq36WvjQqFGsX3Gik99NV+VXp/PW3n+Q62xyPdbvGOCfjPqjW+/SKMig==",
       "dev": true,
       "requires": {
-        "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.7"
+        "markdown-it": "14.0.0",
+        "markdownlint-micromark": "0.1.8"
       }
     },
     "markdownlint-cli2": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.10.0.tgz",
-      "integrity": "sha512-kVxjPyKFC+eW7iqcxiNI50RDzwugpXkEX5eQlDso/0IUs9M73jXYguLFHDzgi5KatcxU/57Fu8KoGtkFft9lfA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.12.1.tgz",
+      "integrity": "sha512-RcK+l5FjJEyrU3REhrThiEUXNK89dLYNJCYbvOUKypxqIGfkcgpz8g08EKqhrmUbYfYoLC5nEYQy53NhJSEtfQ==",
       "dev": true,
       "requires": {
-        "globby": "13.2.2",
-        "markdownlint": "0.31.1",
+        "globby": "14.0.0",
+        "jsonc-parser": "3.2.0",
+        "markdownlint": "0.33.0",
         "markdownlint-cli2-formatter-default": "0.0.4",
         "micromatch": "4.0.5",
-        "strip-json-comments": "5.0.1",
-        "yaml": "2.3.2"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
-          "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
-          "dev": true
-        }
+        "yaml": "2.3.4"
       }
     },
     "markdownlint-cli2-formatter-default": {
@@ -6791,15 +6900,15 @@
       "requires": {}
     },
     "markdownlint-micromark": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.7.tgz",
-      "integrity": "sha512-BbRPTC72fl5vlSKv37v/xIENSRDYL/7X/XoFzZ740FGEbs9vZerLrIkFRY0rv7slQKxDczToYuMmqQFN61fi4Q==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.8.tgz",
+      "integrity": "sha512-1ouYkMRo9/6gou9gObuMDnvZM8jC/ly3QCFQyoSPCS2XV1ZClU0xpKbL1Ar3bWWRT1RnBZkWUEiNKrI2CwiBQA==",
       "dev": true
     },
     "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "merge2": {
@@ -7008,9 +7117,9 @@
       "dev": true
     },
     "path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
       "dev": true
     },
     "picomatch": {
@@ -7101,6 +7210,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
     "queue-microtask": {
@@ -7222,9 +7337,9 @@
       }
     },
     "slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true
     },
     "standard": {
@@ -7404,9 +7519,9 @@
       }
     },
     "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.0.0.tgz",
+      "integrity": "sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==",
       "dev": true
     },
     "unbox-primitive": {
@@ -7420,6 +7535,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -7507,9 +7628,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
-      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "test": "standard && markdownlint-cli2 '*.md' '**/*.md' '#node_modules'"
   },
   "dependencies": {
-    "@aws-sdk/client-route-53": "^3.438.0",
-    "@aws-sdk/client-ses": "^3.438.0",
-    "dotenv": "^16.3.1",
+    "@aws-sdk/client-route-53": "^3.515.0",
+    "@aws-sdk/client-ses": "^3.515.0",
+    "dotenv": "^16.4.4",
     "log4js": "^6.9.1"
   },
   "engines": {
@@ -20,7 +20,7 @@
   "private": true,
   "license": "MIT",
   "devDependencies": {
-    "markdownlint-cli2": "^0.10.0",
+    "markdownlint-cli2": "^0.12.1",
     "standard": "^17.1.0"
   }
 }


### PR DESCRIPTION
- upgrade node dependencies to latest release
- upgrade github workflow actions to latest release
- update Node from v18 to v20 (breaking)

Breaking change: ARMv6 has reached EOL at February 2022 and docker build for Node v20 is not supported for ARMv6 anymore.