### PR TITLE
fix(node): downgrade node from v21 to v20

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Set version of node to use
-      - name: Use Node.js 21
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 21.x
+          node-version: 20.x
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Set version of node to use
-      - name: Use Node.js 21
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 21.x
+          node-version: 20.x
 
       # This command is similar to npm install, except it's meant to be used in
       # automated environments such as test platforms, continuous integration,

--- a/.github/workflows/snyk_container-analysis.yml
+++ b/.github/workflows/snyk_container-analysis.yml
@@ -56,9 +56,9 @@ jobs:
           image: sjmayotte/route53-dynamic-dns
           args: --file=Dockerfile
         # Related to snyk issue: https://github.com/github/codeql-action/issues/2187
-      - name: Replace security-severity undefined for license-related findings
+      - name: Replace security-severity null for license-related findings
         run: >
-          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+          sed -i 's/"security-severity": "null"/"security-severity": "0"/g' snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/snyk_container-analysis.yml
+++ b/.github/workflows/snyk_container-analysis.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           image: sjmayotte/route53-dynamic-dns
           args: --file=Dockerfile
+        # Related to snyk issue: https://github.com/github/codeql-action/issues/2187
+      - name: Replace security-severity undefined for license-related findings
+        run: >
+          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:20.11.1-bookworm-slim
+FROM node:20.12.2-bookworm-slim
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG GIT_SHA
 ENV NODE_ENV production
 
 # Install timezone database to allow setting timezone through TZ environment variable
-RUN apk add --no-cache tzdata
+RUN apt install tzdata
 
 LABEL org.opencontainers.image.created=$BUILD_DATE \
   org.opencontainers.image.authors="Steven Mayotte" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:21.7.0-alpine
+FROM node:20.11.1-bookworm-slim
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE


### PR DESCRIPTION
Upgrading node to v21, in hope to mitigate several security warnings, did not succeed. Issues with snyk and sarif file upload stop the migration. Trying to downgrade node to v20.