### PR TITLE
chore: upgrade Node to v24.4.1 and node dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use offical Node.js image.  The image uses Apline Linux
-FROM node:24.3.0-alpine3.21
+FROM node:24.4.1-alpine3.21
 
 # Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.848.0",
         "@aws-sdk/client-ses": "^3.848.0",
-        "dotenv": "^17.0.1",
+        "dotenv": "^17.2.0",
         "log4js": "^6.9.1"
       },
       "devDependencies": {
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.1.tgz",
-      "integrity": "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7701,9 +7701,9 @@
       }
     },
     "dotenv": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.1.tgz",
-      "integrity": "sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA=="
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ=="
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "route53dynamicdns",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "route53dynamicdns",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-route-53": "^3.843.0",
+        "@aws-sdk/client-route-53": "^3.848.0",
         "@aws-sdk/client-ses": "^3.840.0",
         "dotenv": "^17.0.1",
         "log4js": "^6.9.1"
@@ -19,7 +19,7 @@
         "standard": "^17.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -138,47 +138,47 @@
       }
     },
     "node_modules/@aws-sdk/client-route-53": {
-      "version": "3.843.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.843.0.tgz",
-      "integrity": "sha512-f2d72D0WWe+JHVs7JIVtgqWKtGm1h1qJxpU8PyWDHLZbzec0YGpfp2jjOEsNr8yYM/GSv2gdua5J1IPi+hEi6A==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.848.0.tgz",
+      "integrity": "sha512-5RjmKqePSBy6788HJ6OMRI98l56XEPcFd3MPIyP0nNAwp7x6Mppc0V5zfCKglM8TRFjtbiVWjNH2SuDBzISiEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
         "@aws-sdk/middleware-sdk-route53": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@aws-sdk/xml-builder": "3.821.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -189,6 +189,373 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/client-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+      "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/core": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+      "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+      "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+      "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+      "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+      "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+      "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+      "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/token-providers": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+      "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/token-providers": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-route-53/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@aws-sdk/client-ses": {
       "version": "3.840.0",
@@ -868,9 +1235,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
+      "integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.8",
@@ -879,7 +1246,7 @@
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -904,9 +1271,9 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -974,12 +1341,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz",
-      "integrity": "sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
+      "integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.6.0",
+        "@smithy/core": "^3.7.1",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -993,15 +1360,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz",
-      "integrity": "sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
+      "integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -1055,9 +1422,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.4",
@@ -1168,17 +1535,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.5.tgz",
-      "integrity": "sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
+      "integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.6.0",
-        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-endpoint": "^4.1.16",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1275,13 +1642,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz",
-      "integrity": "sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
+      "integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -1291,16 +1658,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz",
-      "integrity": "sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
+      "integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -1362,13 +1729,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
@@ -6282,52 +6649,340 @@
       }
     },
     "@aws-sdk/client-route-53": {
-      "version": "3.843.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.843.0.tgz",
-      "integrity": "sha512-f2d72D0WWe+JHVs7JIVtgqWKtGm1h1qJxpU8PyWDHLZbzec0YGpfp2jjOEsNr8yYM/GSv2gdua5J1IPi+hEi6A==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.848.0.tgz",
+      "integrity": "sha512-5RjmKqePSBy6788HJ6OMRI98l56XEPcFd3MPIyP0nNAwp7x6Mppc0V5zfCKglM8TRFjtbiVWjNH2SuDBzISiEw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
         "@aws-sdk/middleware-sdk-route53": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@aws-sdk/xml-builder": "3.821.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
         "@smithy/util-utf8": "^4.0.0",
         "@smithy/util-waiter": "^4.0.6",
         "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+          "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/middleware-host-header": "3.840.0",
+            "@aws-sdk/middleware-logger": "3.840.0",
+            "@aws-sdk/middleware-recursion-detection": "3.840.0",
+            "@aws-sdk/middleware-user-agent": "3.848.0",
+            "@aws-sdk/region-config-resolver": "3.840.0",
+            "@aws-sdk/types": "3.840.0",
+            "@aws-sdk/util-endpoints": "3.848.0",
+            "@aws-sdk/util-user-agent-browser": "3.840.0",
+            "@aws-sdk/util-user-agent-node": "3.848.0",
+            "@smithy/config-resolver": "^4.1.4",
+            "@smithy/core": "^3.7.0",
+            "@smithy/fetch-http-handler": "^5.1.0",
+            "@smithy/hash-node": "^4.0.4",
+            "@smithy/invalid-dependency": "^4.0.4",
+            "@smithy/middleware-content-length": "^4.0.4",
+            "@smithy/middleware-endpoint": "^4.1.15",
+            "@smithy/middleware-retry": "^4.1.16",
+            "@smithy/middleware-serde": "^4.0.8",
+            "@smithy/middleware-stack": "^4.0.4",
+            "@smithy/node-config-provider": "^4.1.3",
+            "@smithy/node-http-handler": "^4.1.0",
+            "@smithy/protocol-http": "^5.1.2",
+            "@smithy/smithy-client": "^4.4.7",
+            "@smithy/types": "^4.3.1",
+            "@smithy/url-parser": "^4.0.4",
+            "@smithy/util-base64": "^4.0.0",
+            "@smithy/util-body-length-browser": "^4.0.0",
+            "@smithy/util-body-length-node": "^4.0.0",
+            "@smithy/util-defaults-mode-browser": "^4.0.23",
+            "@smithy/util-defaults-mode-node": "^4.0.23",
+            "@smithy/util-endpoints": "^3.0.6",
+            "@smithy/util-middleware": "^4.0.4",
+            "@smithy/util-retry": "^4.0.6",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.846.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+          "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+          "requires": {
+            "@aws-sdk/types": "3.840.0",
+            "@aws-sdk/xml-builder": "3.821.0",
+            "@smithy/core": "^3.7.0",
+            "@smithy/node-config-provider": "^4.1.3",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/protocol-http": "^5.1.2",
+            "@smithy/signature-v4": "^5.1.2",
+            "@smithy/smithy-client": "^4.4.7",
+            "@smithy/types": "^4.3.1",
+            "@smithy/util-base64": "^4.0.0",
+            "@smithy/util-body-length-browser": "^4.0.0",
+            "@smithy/util-middleware": "^4.0.4",
+            "@smithy/util-utf8": "^4.0.0",
+            "fast-xml-parser": "5.2.5",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.846.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+          "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.846.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+          "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/fetch-http-handler": "^5.1.0",
+            "@smithy/node-http-handler": "^4.1.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/protocol-http": "^5.1.2",
+            "@smithy/smithy-client": "^4.4.7",
+            "@smithy/types": "^4.3.1",
+            "@smithy/util-stream": "^4.2.3",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+          "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/credential-provider-env": "3.846.0",
+            "@aws-sdk/credential-provider-http": "3.846.0",
+            "@aws-sdk/credential-provider-process": "3.846.0",
+            "@aws-sdk/credential-provider-sso": "3.848.0",
+            "@aws-sdk/credential-provider-web-identity": "3.848.0",
+            "@aws-sdk/nested-clients": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/credential-provider-imds": "^4.0.6",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/shared-ini-file-loader": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+          "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.846.0",
+            "@aws-sdk/credential-provider-http": "3.846.0",
+            "@aws-sdk/credential-provider-ini": "3.848.0",
+            "@aws-sdk/credential-provider-process": "3.846.0",
+            "@aws-sdk/credential-provider-sso": "3.848.0",
+            "@aws-sdk/credential-provider-web-identity": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/credential-provider-imds": "^4.0.6",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/shared-ini-file-loader": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.846.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+          "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/shared-ini-file-loader": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+          "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.848.0",
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/token-providers": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/shared-ini-file-loader": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+          "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/nested-clients": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+          "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/types": "3.840.0",
+            "@aws-sdk/util-endpoints": "3.848.0",
+            "@smithy/core": "^3.7.0",
+            "@smithy/protocol-http": "^5.1.2",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/nested-clients": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+          "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "5.2.0",
+            "@aws-crypto/sha256-js": "5.2.0",
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/middleware-host-header": "3.840.0",
+            "@aws-sdk/middleware-logger": "3.840.0",
+            "@aws-sdk/middleware-recursion-detection": "3.840.0",
+            "@aws-sdk/middleware-user-agent": "3.848.0",
+            "@aws-sdk/region-config-resolver": "3.840.0",
+            "@aws-sdk/types": "3.840.0",
+            "@aws-sdk/util-endpoints": "3.848.0",
+            "@aws-sdk/util-user-agent-browser": "3.840.0",
+            "@aws-sdk/util-user-agent-node": "3.848.0",
+            "@smithy/config-resolver": "^4.1.4",
+            "@smithy/core": "^3.7.0",
+            "@smithy/fetch-http-handler": "^5.1.0",
+            "@smithy/hash-node": "^4.0.4",
+            "@smithy/invalid-dependency": "^4.0.4",
+            "@smithy/middleware-content-length": "^4.0.4",
+            "@smithy/middleware-endpoint": "^4.1.15",
+            "@smithy/middleware-retry": "^4.1.16",
+            "@smithy/middleware-serde": "^4.0.8",
+            "@smithy/middleware-stack": "^4.0.4",
+            "@smithy/node-config-provider": "^4.1.3",
+            "@smithy/node-http-handler": "^4.1.0",
+            "@smithy/protocol-http": "^5.1.2",
+            "@smithy/smithy-client": "^4.4.7",
+            "@smithy/types": "^4.3.1",
+            "@smithy/url-parser": "^4.0.4",
+            "@smithy/util-base64": "^4.0.0",
+            "@smithy/util-body-length-browser": "^4.0.0",
+            "@smithy/util-body-length-node": "^4.0.0",
+            "@smithy/util-defaults-mode-browser": "^4.0.23",
+            "@smithy/util-defaults-mode-node": "^4.0.23",
+            "@smithy/util-endpoints": "^3.0.6",
+            "@smithy/util-middleware": "^4.0.4",
+            "@smithy/util-retry": "^4.0.6",
+            "@smithy/util-utf8": "^4.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+          "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
+          "requires": {
+            "@aws-sdk/core": "3.846.0",
+            "@aws-sdk/nested-clients": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/property-provider": "^4.0.4",
+            "@smithy/shared-ini-file-loader": "^4.0.4",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+          "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
+          "requires": {
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/types": "^4.3.1",
+            "@smithy/url-parser": "^4.0.4",
+            "@smithy/util-endpoints": "^3.0.6",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.848.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+          "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
+          "requires": {
+            "@aws-sdk/middleware-user-agent": "3.848.0",
+            "@aws-sdk/types": "3.840.0",
+            "@smithy/node-config-provider": "^4.1.3",
+            "@smithy/types": "^4.3.1",
+            "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "5.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+          "requires": {
+            "strnum": "^2.1.0"
+          }
+        },
+        "strnum": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+          "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
+        }
       }
     },
     "@aws-sdk/client-ses": {
@@ -6856,9 +7511,9 @@
       }
     },
     "@smithy/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
+      "integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
       "requires": {
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/protocol-http": "^5.1.2",
@@ -6866,7 +7521,7 @@
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       }
@@ -6884,9 +7539,9 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
       "requires": {
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/querystring-builder": "^4.0.4",
@@ -6934,11 +7589,11 @@
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz",
-      "integrity": "sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
+      "integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
       "requires": {
-        "@smithy/core": "^3.6.0",
+        "@smithy/core": "^3.7.1",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -6949,14 +7604,14 @@
       }
     },
     "@smithy/middleware-retry": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz",
-      "integrity": "sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==",
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
+      "integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
       "requires": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -6995,9 +7650,9 @@
       }
     },
     "@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
       "requires": {
         "@smithy/abort-controller": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
@@ -7076,16 +7731,16 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.5.tgz",
-      "integrity": "sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
+      "integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
       "requires": {
-        "@smithy/core": "^3.6.0",
-        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-endpoint": "^4.1.16",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
       }
     },
@@ -7151,27 +7806,27 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz",
-      "integrity": "sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
+      "integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
       "requires": {
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz",
-      "integrity": "sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==",
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
+      "integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
       "requires": {
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.8",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       }
@@ -7214,12 +7869,12 @@
       }
     },
     "@smithy/util-stream": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
       "requires": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.848.0",
-        "@aws-sdk/client-ses": "^3.840.0",
+        "@aws-sdk/client-ses": "^3.848.0",
         "dotenv": "^17.0.1",
         "log4js": "^6.9.1"
       },
@@ -190,7 +190,58 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-ses": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.848.0.tgz",
+      "integrity": "sha512-CyDE1KqM3U9oS2aNn2eiCNlVsMdT7j3yEJQc+qrLJAvVKDirfdDtdBTzHLvi8oJoeXcvUHFrTOOBuHvyvulsbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
       "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
@@ -239,7 +290,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/core": {
+    "node_modules/@aws-sdk/core": {
       "version": "3.846.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
       "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
@@ -265,7 +316,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-env": {
+    "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.846.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
       "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
@@ -281,7 +332,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-http": {
+    "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.846.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
       "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
@@ -302,7 +353,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-ini": {
+    "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
       "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
@@ -326,7 +377,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-node": {
+    "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
       "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
@@ -349,7 +400,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-process": {
+    "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.846.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
       "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
@@ -366,7 +417,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-sso": {
+    "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
       "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
@@ -385,7 +436,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/credential-provider-web-identity": {
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.848.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
       "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
@@ -393,424 +444,6 @@
       "dependencies": {
         "@aws-sdk/core": "3.846.0",
         "@aws-sdk/nested-clients": "3.848.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.848.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
-      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.846.0",
-        "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.848.0",
-        "@smithy/core": "^3.7.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.848.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
-      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.846.0",
-        "@aws-sdk/middleware-host-header": "3.840.0",
-        "@aws-sdk/middleware-logger": "3.840.0",
-        "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.848.0",
-        "@aws-sdk/region-config-resolver": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.848.0",
-        "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.848.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.7.0",
-        "@smithy/fetch-http-handler": "^5.1.0",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.15",
-        "@smithy/middleware-retry": "^4.1.16",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.1.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.7",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.23",
-        "@smithy/util-defaults-mode-node": "^4.0.23",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/token-providers": {
-      "version": "3.848.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
-      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.846.0",
-        "@aws-sdk/nested-clients": "3.848.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.848.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
-      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.848.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
-      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.848.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@aws-sdk/client-ses": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.840.0.tgz",
-      "integrity": "sha512-RTIVFrAGDAOJ0xWFgCf9q0y1QrfPOCn1O6fKfjqwGig0XjwQH/YbxwC6wfV24/JAPrt2qRjkSU6SvBSVcHp9+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-node": "3.840.0",
-        "@aws-sdk/middleware-host-header": "3.840.0",
-        "@aws-sdk/middleware-logger": "3.840.0",
-        "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
-        "@aws-sdk/region-config-resolver": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
-        "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.840.0.tgz",
-      "integrity": "sha512-3Zp+FWN2hhmKdpS0Ragi5V2ZPsZNScE3jlbgoJjzjI/roHZqO+e3/+XFN4TlM0DsPKYJNp+1TAjmhxN6rOnfYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/middleware-host-header": "3.840.0",
-        "@aws-sdk/middleware-logger": "3.840.0",
-        "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
-        "@aws-sdk/region-config-resolver": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
-        "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.840.0.tgz",
-      "integrity": "sha512-x3Zgb39tF1h2XpU+yA4OAAQlW6LVEfXNlSedSYJ7HGKXqA/E9h3rWQVpYfhXXVVsLdYXdNw5KBUkoAoruoZSZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.6.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.840.0.tgz",
-      "integrity": "sha512-EzF6VcJK7XvQ/G15AVEfJzN2mNXU8fcVpXo4bRyr1S6t2q5zx6UPH/XjDbn18xyUmOq01t+r8gG+TmHEVo18fA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.840.0.tgz",
-      "integrity": "sha512-wbnUiPGLVea6mXbUh04fu+VJmGkQvmToPeTYdHE8eRZq3NRDi3t3WltT+jArLBKD/4NppRpMjf2ju4coMCz91g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.840.0.tgz",
-      "integrity": "sha512-7F290BsWydShHb+7InXd+IjJc3mlEIm9I0R57F/Pjl1xZB69MdkhVGCnuETWoBt4g53ktJd6NEjzm/iAhFXFmw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-env": "3.840.0",
-        "@aws-sdk/credential-provider-http": "3.840.0",
-        "@aws-sdk/credential-provider-process": "3.840.0",
-        "@aws-sdk/credential-provider-sso": "3.840.0",
-        "@aws-sdk/credential-provider-web-identity": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.840.0.tgz",
-      "integrity": "sha512-KufP8JnxA31wxklLm63evUPSFApGcH8X86z3mv9SRbpCm5ycgWIGVCTXpTOdgq6rPZrwT9pftzv2/b4mV/9clg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.840.0",
-        "@aws-sdk/credential-provider-http": "3.840.0",
-        "@aws-sdk/credential-provider-ini": "3.840.0",
-        "@aws-sdk/credential-provider-process": "3.840.0",
-        "@aws-sdk/credential-provider-sso": "3.840.0",
-        "@aws-sdk/credential-provider-web-identity": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.840.0.tgz",
-      "integrity": "sha512-HkDQWHy8tCI4A0Ps2NVtuVYMv9cB4y/IuD/TdOsqeRIAT12h8jDb98BwQPNLAImAOwOWzZJ8Cu0xtSpX7CQhMw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.840.0.tgz",
-      "integrity": "sha512-2qgdtdd6R0Z1y0KL8gzzwFUGmhBHSUx4zy85L2XV1CXhpRNwV71SVWJqLDVV5RVWVf9mg50Pm3AWrUC0xb0pcA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.840.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/token-providers": "3.840.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.840.0.tgz",
-      "integrity": "sha512-dpEeVXG8uNZSmVXReE4WP0lwoioX2gstk4RnUgrdUE3YaPq8A+hJiVAyc3h+cjDeIqfbsQbZm9qFetKC2LF9dQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -879,15 +512,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.840.0.tgz",
-      "integrity": "sha512-hiiMf7BP5ZkAFAvWRcK67Mw/g55ar7OCrvrynC92hunx/xhMkrgSLM0EXIZ1oTn3uql9kH/qqGF0nqsK6K555A==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
-        "@smithy/core": "^3.6.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@smithy/core": "^3.7.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -897,44 +530,44 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.840.0.tgz",
-      "integrity": "sha512-LXYYo9+n4hRqnRSIMXLBb+BLz+cEmjMtTudwK1BF6Bn2RfdDv29KuyeDRrPCS3TwKl7ZKmXUmE9n5UuHAPfBpA==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -963,13 +596,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.840.0.tgz",
-      "integrity": "sha512-6BuTOLTXvmgwjK7ve7aTg9JaWFdM5UoMolLVPMyh3wTv9Ufalh8oklxYHUBIxsKkBGO2WiHXytveuxH6tAgTYg==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -994,13 +627,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.840.0.tgz",
-      "integrity": "sha512-eqE9ROdg/Kk0rj3poutyRCFauPDXIf/WSvCqFiRDDVi6QOnCv/M0g2XW8/jSvkJlOyaXkNCptapIp6BeeFFGYw==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-endpoints": "^3.0.6",
         "tslib": "^2.6.2"
       },
@@ -1032,12 +666,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.840.0.tgz",
-      "integrity": "sha512-Fy5JUEDQU1tPm2Yw/YqRYYc27W5+QD/J4mYvQvdWjUGZLB5q3eLFMGD35Uc28ZFoGMufPr4OCxK/bRfWROBRHQ==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
@@ -3205,22 +2839,18 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6150,9 +5780,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "funding": [
         {
           "type": "github",
@@ -6695,335 +6325,47 @@
         "@smithy/util-utf8": "^4.0.0",
         "@smithy/util-waiter": "^4.0.6",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
-          "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/middleware-host-header": "3.840.0",
-            "@aws-sdk/middleware-logger": "3.840.0",
-            "@aws-sdk/middleware-recursion-detection": "3.840.0",
-            "@aws-sdk/middleware-user-agent": "3.848.0",
-            "@aws-sdk/region-config-resolver": "3.840.0",
-            "@aws-sdk/types": "3.840.0",
-            "@aws-sdk/util-endpoints": "3.848.0",
-            "@aws-sdk/util-user-agent-browser": "3.840.0",
-            "@aws-sdk/util-user-agent-node": "3.848.0",
-            "@smithy/config-resolver": "^4.1.4",
-            "@smithy/core": "^3.7.0",
-            "@smithy/fetch-http-handler": "^5.1.0",
-            "@smithy/hash-node": "^4.0.4",
-            "@smithy/invalid-dependency": "^4.0.4",
-            "@smithy/middleware-content-length": "^4.0.4",
-            "@smithy/middleware-endpoint": "^4.1.15",
-            "@smithy/middleware-retry": "^4.1.16",
-            "@smithy/middleware-serde": "^4.0.8",
-            "@smithy/middleware-stack": "^4.0.4",
-            "@smithy/node-config-provider": "^4.1.3",
-            "@smithy/node-http-handler": "^4.1.0",
-            "@smithy/protocol-http": "^5.1.2",
-            "@smithy/smithy-client": "^4.4.7",
-            "@smithy/types": "^4.3.1",
-            "@smithy/url-parser": "^4.0.4",
-            "@smithy/util-base64": "^4.0.0",
-            "@smithy/util-body-length-browser": "^4.0.0",
-            "@smithy/util-body-length-node": "^4.0.0",
-            "@smithy/util-defaults-mode-browser": "^4.0.23",
-            "@smithy/util-defaults-mode-node": "^4.0.23",
-            "@smithy/util-endpoints": "^3.0.6",
-            "@smithy/util-middleware": "^4.0.4",
-            "@smithy/util-retry": "^4.0.6",
-            "@smithy/util-utf8": "^4.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/core": {
-          "version": "3.846.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
-          "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
-          "requires": {
-            "@aws-sdk/types": "3.840.0",
-            "@aws-sdk/xml-builder": "3.821.0",
-            "@smithy/core": "^3.7.0",
-            "@smithy/node-config-provider": "^4.1.3",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/protocol-http": "^5.1.2",
-            "@smithy/signature-v4": "^5.1.2",
-            "@smithy/smithy-client": "^4.4.7",
-            "@smithy/types": "^4.3.1",
-            "@smithy/util-base64": "^4.0.0",
-            "@smithy/util-body-length-browser": "^4.0.0",
-            "@smithy/util-middleware": "^4.0.4",
-            "@smithy/util-utf8": "^4.0.0",
-            "fast-xml-parser": "5.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.846.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
-          "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.846.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
-          "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/fetch-http-handler": "^5.1.0",
-            "@smithy/node-http-handler": "^4.1.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/protocol-http": "^5.1.2",
-            "@smithy/smithy-client": "^4.4.7",
-            "@smithy/types": "^4.3.1",
-            "@smithy/util-stream": "^4.2.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
-          "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/credential-provider-env": "3.846.0",
-            "@aws-sdk/credential-provider-http": "3.846.0",
-            "@aws-sdk/credential-provider-process": "3.846.0",
-            "@aws-sdk/credential-provider-sso": "3.848.0",
-            "@aws-sdk/credential-provider-web-identity": "3.848.0",
-            "@aws-sdk/nested-clients": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/credential-provider-imds": "^4.0.6",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/shared-ini-file-loader": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
-          "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.846.0",
-            "@aws-sdk/credential-provider-http": "3.846.0",
-            "@aws-sdk/credential-provider-ini": "3.848.0",
-            "@aws-sdk/credential-provider-process": "3.846.0",
-            "@aws-sdk/credential-provider-sso": "3.848.0",
-            "@aws-sdk/credential-provider-web-identity": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/credential-provider-imds": "^4.0.6",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/shared-ini-file-loader": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.846.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
-          "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/shared-ini-file-loader": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
-          "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.848.0",
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/token-providers": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/shared-ini-file-loader": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
-          "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/nested-clients": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
-          "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/types": "3.840.0",
-            "@aws-sdk/util-endpoints": "3.848.0",
-            "@smithy/core": "^3.7.0",
-            "@smithy/protocol-http": "^5.1.2",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/nested-clients": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
-          "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/middleware-host-header": "3.840.0",
-            "@aws-sdk/middleware-logger": "3.840.0",
-            "@aws-sdk/middleware-recursion-detection": "3.840.0",
-            "@aws-sdk/middleware-user-agent": "3.848.0",
-            "@aws-sdk/region-config-resolver": "3.840.0",
-            "@aws-sdk/types": "3.840.0",
-            "@aws-sdk/util-endpoints": "3.848.0",
-            "@aws-sdk/util-user-agent-browser": "3.840.0",
-            "@aws-sdk/util-user-agent-node": "3.848.0",
-            "@smithy/config-resolver": "^4.1.4",
-            "@smithy/core": "^3.7.0",
-            "@smithy/fetch-http-handler": "^5.1.0",
-            "@smithy/hash-node": "^4.0.4",
-            "@smithy/invalid-dependency": "^4.0.4",
-            "@smithy/middleware-content-length": "^4.0.4",
-            "@smithy/middleware-endpoint": "^4.1.15",
-            "@smithy/middleware-retry": "^4.1.16",
-            "@smithy/middleware-serde": "^4.0.8",
-            "@smithy/middleware-stack": "^4.0.4",
-            "@smithy/node-config-provider": "^4.1.3",
-            "@smithy/node-http-handler": "^4.1.0",
-            "@smithy/protocol-http": "^5.1.2",
-            "@smithy/smithy-client": "^4.4.7",
-            "@smithy/types": "^4.3.1",
-            "@smithy/url-parser": "^4.0.4",
-            "@smithy/util-base64": "^4.0.0",
-            "@smithy/util-body-length-browser": "^4.0.0",
-            "@smithy/util-body-length-node": "^4.0.0",
-            "@smithy/util-defaults-mode-browser": "^4.0.23",
-            "@smithy/util-defaults-mode-node": "^4.0.23",
-            "@smithy/util-endpoints": "^3.0.6",
-            "@smithy/util-middleware": "^4.0.4",
-            "@smithy/util-retry": "^4.0.6",
-            "@smithy/util-utf8": "^4.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
-          "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
-          "requires": {
-            "@aws-sdk/core": "3.846.0",
-            "@aws-sdk/nested-clients": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/property-provider": "^4.0.4",
-            "@smithy/shared-ini-file-loader": "^4.0.4",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
-          "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
-          "requires": {
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/types": "^4.3.1",
-            "@smithy/url-parser": "^4.0.4",
-            "@smithy/util-endpoints": "^3.0.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.848.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
-          "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
-          "requires": {
-            "@aws-sdk/middleware-user-agent": "3.848.0",
-            "@aws-sdk/types": "3.840.0",
-            "@smithy/node-config-provider": "^4.1.3",
-            "@smithy/types": "^4.3.1",
-            "tslib": "^2.6.2"
-          }
-        },
-        "fast-xml-parser": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-          "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-          "requires": {
-            "strnum": "^2.1.0"
-          }
-        },
-        "strnum": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-          "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
-        }
       }
     },
     "@aws-sdk/client-ses": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.840.0.tgz",
-      "integrity": "sha512-RTIVFrAGDAOJ0xWFgCf9q0y1QrfPOCn1O6fKfjqwGig0XjwQH/YbxwC6wfV24/JAPrt2qRjkSU6SvBSVcHp9+w==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.848.0.tgz",
+      "integrity": "sha512-CyDE1KqM3U9oS2aNn2eiCNlVsMdT7j3yEJQc+qrLJAvVKDirfdDtdBTzHLvi8oJoeXcvUHFrTOOBuHvyvulsbw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -7033,43 +6375,43 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.840.0.tgz",
-      "integrity": "sha512-3Zp+FWN2hhmKdpS0Ragi5V2ZPsZNScE3jlbgoJjzjI/roHZqO+e3/+XFN4TlM0DsPKYJNp+1TAjmhxN6rOnfYA==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+      "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -7078,33 +6420,33 @@
       }
     },
     "@aws-sdk/core": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.840.0.tgz",
-      "integrity": "sha512-x3Zgb39tF1h2XpU+yA4OAAQlW6LVEfXNlSedSYJ7HGKXqA/E9h3rWQVpYfhXXVVsLdYXdNw5KBUkoAoruoZSZA==",
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+      "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
       "requires": {
         "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.6.0",
+        "@smithy/core": "^3.7.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.840.0.tgz",
-      "integrity": "sha512-EzF6VcJK7XvQ/G15AVEfJzN2mNXU8fcVpXo4bRyr1S6t2q5zx6UPH/XjDbn18xyUmOq01t+r8gG+TmHEVo18fA==",
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+      "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -7112,34 +6454,34 @@
       }
     },
     "@aws-sdk/credential-provider-http": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.840.0.tgz",
-      "integrity": "sha512-wbnUiPGLVea6mXbUh04fu+VJmGkQvmToPeTYdHE8eRZq3NRDi3t3WltT+jArLBKD/4NppRpMjf2ju4coMCz91g==",
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+      "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.840.0.tgz",
-      "integrity": "sha512-7F290BsWydShHb+7InXd+IjJc3mlEIm9I0R57F/Pjl1xZB69MdkhVGCnuETWoBt4g53ktJd6NEjzm/iAhFXFmw==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+      "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/credential-provider-env": "3.840.0",
-        "@aws-sdk/credential-provider-http": "3.840.0",
-        "@aws-sdk/credential-provider-process": "3.840.0",
-        "@aws-sdk/credential-provider-sso": "3.840.0",
-        "@aws-sdk/credential-provider-web-identity": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -7149,16 +6491,16 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.840.0.tgz",
-      "integrity": "sha512-KufP8JnxA31wxklLm63evUPSFApGcH8X86z3mv9SRbpCm5ycgWIGVCTXpTOdgq6rPZrwT9pftzv2/b4mV/9clg==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+      "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.840.0",
-        "@aws-sdk/credential-provider-http": "3.840.0",
-        "@aws-sdk/credential-provider-ini": "3.840.0",
-        "@aws-sdk/credential-provider-process": "3.840.0",
-        "@aws-sdk/credential-provider-sso": "3.840.0",
-        "@aws-sdk/credential-provider-web-identity": "3.840.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -7168,11 +6510,11 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.840.0.tgz",
-      "integrity": "sha512-HkDQWHy8tCI4A0Ps2NVtuVYMv9cB4y/IuD/TdOsqeRIAT12h8jDb98BwQPNLAImAOwOWzZJ8Cu0xtSpX7CQhMw==",
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+      "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -7181,13 +6523,13 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.840.0.tgz",
-      "integrity": "sha512-2qgdtdd6R0Z1y0KL8gzzwFUGmhBHSUx4zy85L2XV1CXhpRNwV71SVWJqLDVV5RVWVf9mg50Pm3AWrUC0xb0pcA==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+      "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.840.0",
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/token-providers": "3.840.0",
+        "@aws-sdk/client-sso": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/token-providers": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -7196,12 +6538,12 @@
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.840.0.tgz",
-      "integrity": "sha512-dpEeVXG8uNZSmVXReE4WP0lwoioX2gstk4RnUgrdUE3YaPq8A+hJiVAyc3h+cjDeIqfbsQbZm9qFetKC2LF9dQ==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+      "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -7251,57 +6593,57 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.840.0.tgz",
-      "integrity": "sha512-hiiMf7BP5ZkAFAvWRcK67Mw/g55ar7OCrvrynC92hunx/xhMkrgSLM0EXIZ1oTn3uql9kH/qqGF0nqsK6K555A==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
-        "@smithy/core": "^3.6.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@smithy/core": "^3.7.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       }
     },
     "@aws-sdk/nested-clients": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.840.0.tgz",
-      "integrity": "sha512-LXYYo9+n4hRqnRSIMXLBb+BLz+cEmjMtTudwK1BF6Bn2RfdDv29KuyeDRrPCS3TwKl7ZKmXUmE9n5UuHAPfBpA==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.6.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.21",
-        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -7323,12 +6665,12 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.840.0.tgz",
-      "integrity": "sha512-6BuTOLTXvmgwjK7ve7aTg9JaWFdM5UoMolLVPMyh3wTv9Ufalh8oklxYHUBIxsKkBGO2WiHXytveuxH6tAgTYg==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
       "requires": {
-        "@aws-sdk/core": "3.840.0",
-        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -7346,12 +6688,13 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.840.0.tgz",
-      "integrity": "sha512-eqE9ROdg/Kk0rj3poutyRCFauPDXIf/WSvCqFiRDDVi6QOnCv/M0g2XW8/jSvkJlOyaXkNCptapIp6BeeFFGYw==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
       "requires": {
         "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-endpoints": "^3.0.6",
         "tslib": "^2.6.2"
       }
@@ -7376,11 +6719,11 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.840.0.tgz",
-      "integrity": "sha512-Fy5JUEDQU1tPm2Yw/YqRYYc27W5+QD/J4mYvQvdWjUGZLB5q3eLFMGD35Uc28ZFoGMufPr4OCxK/bRfWROBRHQ==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
       "requires": {
-        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
@@ -8905,11 +8248,11 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "requires": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       }
     },
     "fastq": {
@@ -10773,9 +10116,9 @@
       "dev": true
     },
     "strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-route-53": "^3.848.0",
     "@aws-sdk/client-ses": "^3.848.0",
-    "dotenv": "^17.0.1",
+    "dotenv": "^17.2.0",
     "log4js": "^6.9.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-route-53": "^3.848.0",
-    "@aws-sdk/client-ses": "^3.840.0",
+    "@aws-sdk/client-ses": "^3.848.0",
     "dotenv": "^17.0.1",
     "log4js": "^6.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "standard && markdownlint-cli2 '*.md' '**/*.md' '#node_modules'"
   },
   "dependencies": {
-    "@aws-sdk/client-route-53": "^3.843.0",
+    "@aws-sdk/client-route-53": "^3.848.0",
     "@aws-sdk/client-ses": "^3.840.0",
     "dotenv": "^17.0.1",
     "log4js": "^6.9.1"


### PR DESCRIPTION
- chore(node): bump node from 24.3.0 to 24.4.1, mitigates high severity vulnerabilities [#389 ](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/389)and [#390](https://github.com/sjmayotte/route53-dynamic-dns/security/code-scanning/390)
- chore(deps): bump @aws-sdk/client-route-53 from 3.843.0 to 3.848.0
- chore(deps): bump @aws-sdk/client-ses from 3.840.0 to 3.848.0
- chore(deps): bump dotenv from 17.0.1 to 17.2.0