### PR TITLE
fix(github): use distinct category for each sarif file to avoid

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -69,3 +69,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.ossar.outputs.sarifFile }}
+          category: ossar

--- a/.github/workflows/snyk_container-analysis.yml
+++ b/.github/workflows/snyk_container-analysis.yml
@@ -63,3 +63,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif
+          category: docker


### PR DESCRIPTION
See https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/